### PR TITLE
Publish action now uses gh-pages to avoid overwriting main

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,10 +21,11 @@ jobs:
       run: npm clean-install
     - name: Run build
       run: npm run build
-    - uses: stefanzweifel/git-auto-commit-action@v4
+    - name: Deploy to gh-pages
+      uses: peaceiris/actions-gh-pages@v3
       with:
-        commit_message: Update github.io page
-        branch: main
-        file_pattern: docs/
-        commit_user_name: cffinit
-        push_options: '--force'
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_dir: ./docs
+        user_name: 'cffinit[bot]'
+        user_email: 'cffinit[bot]@users.noreply.github.com'
+        commit_message: ':robot: Update github.io page'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,7 +25,7 @@ jobs:
       uses: peaceiris/actions-gh-pages@v3
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
-        publish_dir: ./docs
+        publish_dir: ./dist
         user_name: 'cffinit[bot]'
         user_email: 'cffinit[bot]@users.noreply.github.com'
         commit_message: ':robot: Update github.io page'

--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 *.njsproj
 *.sln
 node_modules
+
+# Build files
+docs

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,3 @@ yarn-error.log*
 *.njsproj
 *.sln
 node_modules
-
-# Build files
-docs

--- a/README.dev.md
+++ b/README.dev.md
@@ -84,6 +84,22 @@ To run linting on commit, you can install a git commit hook with
 npx husky install
 ```
 
+## Publishing
+
+This app is published using [GitHub pages](https://github.com/citation-file-format/cff-initializer-javascript/settings/pages) automatically by the [Publish workflow](.github/workflows/publish.yml).
+The way this works is:
+
+- After a commit is pushed to `main`, the workflow runs.
+- The workflow builds the app (using the `npm run build` command) into the folder `./dist`.
+- The GitHub action `peaceiris/actions-gh-pages@v3` pushes the contents of `./dist` to the branch [gh-pages](https://github.com/citation-file-format/cff-initializer-javascript/tree/gh-pages).
+- The `gh-pages` content is served by GitHub into <https://citation-file-format.github.io/cff-initializer-javascript/#/>
+
+For this to work, a few things have to be set up:
+
+- A `gh-pages` has to exist before the action is run (click on the branches dropdown, write `gh-pages` and click "Create").
+- After `gh-pages` is created, select it as the source for deployment of [GitHub pages](https://github.com/citation-file-format/cff-initializer-javascript/settings/pages).
+- Enable write permissions for `secrets.GITHUB_TOKEN` on workflows (see, e.g. [this post](https://github.com/peaceiris/actions-gh-pages/issues/744#issuecomment-1119685318)). This is done on [Settings -> Actions -> General -> Workflow permissions](https://github.com/citation-file-format/cff-initializer-javascript/settings/actions).
+
 ## Making a release
 
 This section describes how to make a release in 2 parts:
@@ -95,7 +111,7 @@ This section describes how to make a release in 2 parts:
 
 1. Verify that the information in `CITATION.cff` is correct
 2. Generate an updated version of `.zenodo.json` if needed using `cffconvert`
-3. Make sure the version field in `package.json` is correct 
+3. Make sure the version field in `package.json` is correct
 4. By running `npm run lint` make sure the linter does not complain
 5. Run the unit tests with `npm run test:unit:ci`
 6. Make sure that github.io page is up to date

--- a/README.dev.md
+++ b/README.dev.md
@@ -94,9 +94,20 @@ The way this works is:
 - The GitHub action `peaceiris/actions-gh-pages@v3` pushes the contents of `./dist` to the branch [gh-pages](https://github.com/citation-file-format/cff-initializer-javascript/tree/gh-pages).
 - The `gh-pages` content is served by GitHub into <https://citation-file-format.github.io/cff-initializer-javascript/#/>
 
-For this to work, a few things have to be set up:
+For this to work, a few things have to be set up for first time use:
 
-- A `gh-pages` has to exist before the action is run (click on the branches dropdown, write `gh-pages` and click "Create").
+- A `gh-pages` has to exist before the action is run. You can create an orphan branch to have a clean history with the following commands:
+
+```bash
+git checkout --orphan gh-pages
+git rm -rf .
+# git rm other files and folders if necessary
+touch index.html
+git add index.html
+git commit -m "gh-pages created"
+git push origin gh-pages
+```
+
 - After `gh-pages` is created, select it as the source for deployment of [GitHub pages](https://github.com/citation-file-format/cff-initializer-javascript/settings/pages).
 - Enable write permissions for `secrets.GITHUB_TOKEN` on workflows (see, e.g. [this post](https://github.com/peaceiris/actions-gh-pages/issues/744#issuecomment-1119685318)). This is done on [Settings -> Actions -> General -> Workflow permissions](https://github.com/citation-file-format/cff-initializer-javascript/settings/actions).
 

--- a/quasar.conf.js
+++ b/quasar.conf.js
@@ -55,7 +55,7 @@ module.exports = configure(function () {
             vueRouterMode: 'hash', // available values: 'hash', 'history'
             publicPath: 'cff-initializer-javascript',
             // transpile: false,
-            distDir: 'docs',
+            distDir: 'dist',
 
             // Add dependencies for transpiling with Babel (Array of string/regex)
             // (from node_modules, which are by default not transpiled).


### PR DESCRIPTION
# Pull request details

## List of related issues or pull requests

Refs: #199


## Describe the changes made in this pull request
Remove the `docs` folder and change the github action to publish it to `gh-pages` after building.
Uses a different action.
Result can be check here:
- https://github.com/abelsiqueira/cff-initializer-javascript/tree/gh-pages
- https://abelsiqueira.github.io/cff-initializer-javascript/#/

<!-- include screenshots if that helps the review -->


## Instructions to review the pull request

<!--

```shell
cd $(mktemp -d --tmpdir cffinit-pr.XXXXXX)
git clone https://github.com/citation-file-format/cffinit .
git checkout <this branch>
npm clean-install
npm run dev
# go to localhost:8080, see if the app works correctly
npm run lint
npm run test:unit:ci
```

-->
