### PR TITLE
Use default colors for up/down buttons

### DIFF
--- a/src/components/AuthorCardEditing.vue
+++ b/src/components/AuthorCardEditing.vue
@@ -119,7 +119,6 @@
 
         <q-card-actions align="right">
             <q-btn
-                color="blue"
                 dense
                 v-bind:disable="index == 0"
                 icon="ion-arrow-up"
@@ -127,7 +126,6 @@
                 v-on:click="$emit('moveUp')"
             />
             <q-btn
-                color="blue"
                 dense
                 v-bind:disable="index >= numAuthors - 1"
                 icon="ion-arrow-down"

--- a/src/components/AuthorCardViewing.vue
+++ b/src/components/AuthorCardViewing.vue
@@ -15,7 +15,7 @@
         <div>
             <q-btn
                 class="author-button"
-                color="blue"
+                flat
                 v-bind:disable="index == 0"
                 icon="ion-arrow-up"
                 tabindex="-1"
@@ -23,7 +23,7 @@
             />
             <q-btn
                 class="author-button"
-                color="blue"
+                flat
                 v-bind:disable="index >= numAuthors - 1"
                 icon="ion-arrow-down"
                 tabindex="-1"

--- a/src/components/IdentifierCardEditing.vue
+++ b/src/components/IdentifierCardEditing.vue
@@ -52,7 +52,6 @@
         <q-card-actions align="right">
             <q-btn
                 dense
-                color="blue"
                 v-bind:disable="index == 0"
                 icon="ion-arrow-up"
                 tabindex="-1"
@@ -60,7 +59,6 @@
             />
             <q-btn
                 dense
-                color="blue"
                 v-bind:disable="index >= numIdentifiers - 1"
                 icon="ion-arrow-down"
                 tabindex="-1"

--- a/src/components/IdentifierCardViewing.vue
+++ b/src/components/IdentifierCardViewing.vue
@@ -14,7 +14,7 @@
         <div>
             <q-btn
                 class="identifier-button"
-                color="blue"
+                flat
                 v-bind:disable="index == 0"
                 icon="ion-arrow-up"
                 tabindex="-1"
@@ -22,7 +22,7 @@
             />
             <q-btn
                 class="identifier-button"
-                color="blue"
+                flat
                 v-bind:disable="index >= numIdentifiers - 1"
                 icon="ion-arrow-down"
                 tabindex="-1"

--- a/src/components/Keyword.vue
+++ b/src/components/Keyword.vue
@@ -14,7 +14,6 @@
         </div>
         <q-btn
             class="keyword-btn"
-            color="blue"
             v-bind:disable="index == 0"
             icon="ion-arrow-up"
             tabindex="-1"
@@ -22,7 +21,6 @@
         />
         <q-btn
             class="keyword-btn"
-            color="blue"
             v-bind:disable="index == numKeywords - 1"
             icon="ion-arrow-down"
             tabindex="-1"


### PR DESCRIPTION
The primary color is dark gray which I dont think is right fit for the buttons so I used default button color which is white.


![localhost_8080_cffinit_ (6)](https://user-images.githubusercontent.com/1713488/139696688-41e9d967-bab0-49eb-b663-e704d686e20e.png)

# Pull request details

## List of related issues or pull requests

Refs: #395


## Describe the changes made in this pull request

<!-- include screenshots if that helps the review -->


## Instructions to review the pull request

The up/down buttons on authors, identifiers and keywords screen should have white background and be similarly shaped as their neighboring buttons.

<!--

```shell
cd $(mktemp -d --tmpdir cffinit-pr.XXXXXX)
git clone https://github.com/citation-file-format/cffinit .
git checkout <this branch>
npm clean-install
npm run dev
# go to localhost:8080, see if the app works correctly
npm run lint
npm run test:unit:ci
```

-->
