### PR TITLE
Add tooltip to info icons: 'Click to access specific documentation'

### DIFF
--- a/src/components/SchemaGuideLink.vue
+++ b/src/components/SchemaGuideLink.vue
@@ -1,6 +1,13 @@
 <template>
     <a v-bind:href="'https://github.com/citation-file-format/citation-file-format/blob/1.2.0/schema-guide.md' + anchor">
         <q-icon name="ion-information-circle-outline" />
+        <q-tooltip
+            anchor="center middle"
+            class="bg-primary text-body2 text-white"
+            self="top left"
+        >
+            Click to access specific documentation
+        </q-tooltip>
     </a>
 </template>
 


### PR DESCRIPTION
# Pull request details

## List of related issues or pull requests

Refs:
- #457 (part of it)

## Describe the changes made in this pull request

Add tooltip to info icons: 'Click to access specific documentation'

![cffinit-tooltip](https://user-images.githubusercontent.com/1068752/167849281-4ea312fb-4aef-4639-9a20-f8028d92c450.jpg)


## Instructions to review the pull request

```shell
cd $(mktemp -d --tmpdir cffinit-pr.XXXXXX)
git clone https://github.com/citation-file-format/cff-initializer-javascript .
git checkout <this branch>
npm clean-install
npm run dev
# go to localhost:8080, see if the app works correctly
npm run lint
npm run test:unit:ci
```
- Check that tooltips appear.