### PR TITLE
Use ajv-errors to change error messages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,13 +5,16 @@
     "requires": true,
     "packages": {
         "": {
+            "name": "cffinit",
             "version": "2.0.0",
             "dependencies": {
                 "@quasar/extras": "^1.0.0",
                 "ajv": "^8.6.2",
+                "ajv-errors": "^3.0.0",
                 "ajv-formats": "^2.1.1",
                 "core-js": "^3.6.5",
                 "deep-filter": "^1.0.2",
+                "deepmerge-json": "^1.3.2",
                 "js-yaml": "^3.14.1",
                 "kebabcase-keys": "^1.0.0",
                 "quasar": "^2.0.0"
@@ -4140,6 +4143,14 @@
                 "url": "https://github.com/sponsors/epoberezkin"
             }
         },
+        "node_modules/ajv-errors": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-3.0.0.tgz",
+            "integrity": "sha512-V3wD15YHfHz6y0KdhYFjyy9vWtEVALT9UrxfN3zqlI6dMioHnJrqOYfyPKol3oqrnCM9uwkcdCwkJ0WUcbLMTQ==",
+            "peerDependencies": {
+                "ajv": "^8.0.1"
+            }
+        },
         "node_modules/ajv-formats": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
@@ -6787,6 +6798,14 @@
             "dev": true,
             "engines": {
                 "node": ">=0.10.0"
+            }
+        },
+        "node_modules/deepmerge-json": {
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/deepmerge-json/-/deepmerge-json-1.3.2.tgz",
+            "integrity": "sha512-aQJepKam/ZgtQqtjS96dNUaRNqHvc9Wpom6of7KIGVjYGfSI2XAh34foiJ8NvwaDLmkJFVTm7kIjmJI+XbBRWg==",
+            "engines": {
+                "node": ">=4.0.0"
             }
         },
         "node_modules/default-gateway": {
@@ -24086,6 +24105,12 @@
                 "uri-js": "^4.2.2"
             }
         },
+        "ajv-errors": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-3.0.0.tgz",
+            "integrity": "sha512-V3wD15YHfHz6y0KdhYFjyy9vWtEVALT9UrxfN3zqlI6dMioHnJrqOYfyPKol3oqrnCM9uwkcdCwkJ0WUcbLMTQ==",
+            "requires": {}
+        },
         "ajv-formats": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
@@ -26113,6 +26138,11 @@
             "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
             "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==",
             "dev": true
+        },
+        "deepmerge-json": {
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/deepmerge-json/-/deepmerge-json-1.3.2.tgz",
+            "integrity": "sha512-aQJepKam/ZgtQqtjS96dNUaRNqHvc9Wpom6of7KIGVjYGfSI2XAh34foiJ8NvwaDLmkJFVTm7kIjmJI+XbBRWg=="
         },
         "default-gateway": {
             "version": "6.0.3",

--- a/package.json
+++ b/package.json
@@ -22,9 +22,11 @@
     "dependencies": {
         "@quasar/extras": "^1.0.0",
         "ajv": "^8.6.2",
+        "ajv-errors": "^3.0.0",
         "ajv-formats": "^2.1.1",
         "core-js": "^3.6.5",
         "deep-filter": "^1.0.2",
+        "deepmerge-json": "^1.3.2",
         "js-yaml": "^3.14.1",
         "kebabcase-keys": "^1.0.0",
         "quasar": "^2.0.0"

--- a/src/components/IdentifierCardEditing.vue
+++ b/src/components/IdentifierCardEditing.vue
@@ -149,7 +149,7 @@ export default defineComponent({
             label: computed(() => linkInfo[props.type].label),
             anchor: computed(() => linkInfo[props.type].anchor),
             typeError: computed(() => getMyErrors(`/identifiers/${props.index}/type`)),
-            valueError: computed(() => getMyErrors(`/identifiers/${props.index}/value`)),
+            valueError: computed(() => getMyErrors(`/identifiers/${props.index}/value`, [], props.type)),
             descriptionError: computed(() =>
                 getMyErrors(`/identifiers/${props.index}/description`)
             ),

--- a/src/components/IdentifierCardEditing.vue
+++ b/src/components/IdentifierCardEditing.vue
@@ -94,7 +94,6 @@
 import { IdentifierTypeType } from '../types'
 import { computed, defineComponent, onMounted, PropType, ref } from 'vue'
 import { getMyErrors } from 'src/store/validator'
-import { identifierErrors } from 'src/identifier-errors'
 import SchemaGuideLink from 'src/components/SchemaGuideLink.vue'
 
 export default defineComponent({
@@ -152,8 +151,7 @@ export default defineComponent({
             valueError: computed(() => getMyErrors(`/identifiers/${props.index}/value`, [], props.type)),
             descriptionError: computed(() =>
                 getMyErrors(`/identifiers/${props.index}/description`)
-            ),
-            identifierErrors: computed(() => identifierErrors(props.index))
+            )
         }
     },
     emits: [

--- a/src/components/IdentifierCardViewing.vue
+++ b/src/components/IdentifierCardViewing.vue
@@ -1,7 +1,7 @@
 <template>
     <q-card
         bordered
-        v-bind:class="['bg-formcard', identifierErrors.hasError ? 'red-border' : '']"
+        v-bind:class="['bg-formcard', identifierHasErrors ? 'red-border' : '']"
         flat
         style="display: flex; flex-direction: row"
     >
@@ -44,7 +44,7 @@
 <script lang="ts">
 import { computed, defineComponent, PropType } from 'vue'
 import { IdentifierType } from 'src/types'
-import { identifierErrors } from 'src/identifier-errors'
+import { identifierHasErrors } from 'src/identifier-errors'
 
 export default defineComponent({
     name: 'IdentifierCardViewing',
@@ -64,7 +64,7 @@ export default defineComponent({
     },
     setup (props) {
         return {
-            identifierErrors: computed(() => identifierErrors(props.index))
+            identifierHasErrors: computed(() => identifierHasErrors(props.index))
         }
     },
     emits: ['editPressed', 'moveDown', 'moveUp']

--- a/src/identifier-errors.ts
+++ b/src/identifier-errors.ts
@@ -1,17 +1,10 @@
-import { messageErrorType, getMyErrors } from 'src/store/validator'
+import { getMyErrors } from 'src/store/validator'
 
-export const identifierErrors = (index:number) => {
-    const myErrors = [
-        getMyErrors(`/identifiers/${index}`)
-    ]
-    const myChildrenErrors = [
+export const identifierHasErrors = (index:number) => {
+    const errors = [
         getMyErrors(`/identifiers/${index}/type`),
         getMyErrors(`/identifiers/${index}/value`),
         getMyErrors(`/identifiers/${index}/description`)
     ]
-    const errors = [...myErrors, ...myChildrenErrors]
-    return {
-        hasError: errors.some(result => result.hasError),
-        messages: errors[0].hasError ? errors[0].messages : []
-    } as messageErrorType
+    return errors.some(result => result.hasError)
 }

--- a/src/identifiers-errors.ts
+++ b/src/identifiers-errors.ts
@@ -1,21 +1,20 @@
 import { IdentifiersType } from 'src/types'
 import { messageErrorType, getMyErrors } from 'src/store/validator'
-import { identifierErrors } from 'src/identifier-errors'
+import { identifierHasErrors } from 'src/identifier-errors'
 
 export const identifiersErrors = (identifiers: IdentifiersType) => {
-    const myErrors = [
+    const errors = [
         getMyErrors('', ['identifiers']),
         getMyErrors('/identifiers')
     ]
-    const myChildrenErrors = identifiers?.map((_, index) => identifierErrors(index))
-    const errors = myChildrenErrors === undefined ? myErrors : [...myErrors, ...myChildrenErrors]
+    const myChildrenHasErrors = identifiers?.some((_, index) => identifierHasErrors(index))
     let allMessages = [] as string[]
     errors.forEach(error => {
         allMessages = allMessages.concat(error.messages)
     })
 
     return {
-        hasError: errors.some(error => error.hasError),
+        hasError: errors.some(error => error.hasError) || myChildrenHasErrors,
         messages: allMessages
     } as messageErrorType
 }

--- a/src/schemas/1.2.0/schema-errors.json
+++ b/src/schemas/1.2.0/schema-errors.json
@@ -19,15 +19,6 @@
         "orcid": {
             "errorMessage": "Format: https://orcid.org/0000-0000-0000-0000"
         },
-        "repository": {
-            "errorMessage": "Format: https://www.example.com (http, ftp, and sftp are also valid)"
-        },
-        "repository-code": {
-            "errorMessage": "Format: https://www.example.com (http, ftp, and sftp are also valid)"
-        },
-        "repository-articaft": {
-            "errorMessage": "Format: https://www.example.com (http, ftp, and sftp are also valid)"
-        },
         "swh-identifier": {
             "errorMessage": "Format: swh:1:xxx:hash"
         },

--- a/src/schemas/1.2.0/schema-errors.json
+++ b/src/schemas/1.2.0/schema-errors.json
@@ -1,0 +1,61 @@
+{
+    "errorMessage": {
+        "required": {
+            "authors": "Needs at least 1 author",
+            "message": "Message can't be blank",
+            "title": "Title can't be blank"
+        }
+    },
+    "definitions": {
+        "date": {
+            "errorMessage": "Format: YYYY-MM-DD"
+        },
+        "doi": {
+            "errorMessage": "Format: 10.XXXX/yyyy"
+        },
+        "email": {
+            "errorMessage": "Format: user@domain.suffix"
+        },
+        "orcid": {
+            "errorMessage": "Format: https://orcid.org/0000-0000-0000-0000"
+        },
+        "repository": {
+            "errorMessage": "Format: https://www.example.com (http, ftp, and sftp are also valid)"
+        },
+        "repository-code": {
+            "errorMessage": "Format: https://www.example.com (http, ftp, and sftp are also valid)"
+        },
+        "repository-articaft": {
+            "errorMessage": "Format: https://www.example.com (http, ftp, and sftp are also valid)"
+        },
+        "swh-identifier": {
+            "errorMessage": "Format: swh:1:xxx:hash"
+        },
+        "url": {
+            "errorMessage": "Format: https://www.example.com (http, ftp, and sftp are also valid)"
+        }
+    },
+    "properties": {
+        "authors": {
+            "errorMessage": {
+                "minItems": "Needs at least 1 author",
+                "uniqueItems": "Each author must be unique"
+            }
+        },
+        "keywords": {
+            "items": {
+                "errorMessage": {
+                    "minLength": "Keyword must be at least 1 characters long"
+                }
+            },
+            "errorMessage": {
+                "uniqueItems": "Each keyword must be unique"
+            }
+        },
+        "identifiers": {
+            "errorMessage": {
+                "uniqueItems": "Each identifier must be unique"
+            }
+        }
+    }
+}

--- a/src/store/errors.ts
+++ b/src/store/errors.ts
@@ -3,11 +3,15 @@ import Ajv, { ErrorObject } from 'ajv'
 import addFormats from 'ajv-formats'
 import { useCffstr } from './cffstr'
 import schema from '../schemas/1.2.0/schema.json'
+import schemaErrors from '../schemas/1.2.0/schema-errors.json'
 import { computed } from 'vue'
+import ajvErrors from 'ajv-errors'
+import merge from 'deepmerge-json'
 
 const ajv = new Ajv({ allErrors: true })
 addFormats(ajv)
-ajv.addSchema(schema)
+ajv.addSchema(merge(schema, schemaErrors))
+ajvErrors(ajv)
 
 type ajvErrorType = ErrorObject<string, Record<string, unknown>, unknown>
 const { jsObject } = useCffstr()

--- a/src/store/validator.ts
+++ b/src/store/validator.ts
@@ -7,10 +7,17 @@ export type messageErrorType = {
     messages: string[]
 }
 
-export function getMyErrors (myPath: string, fieldNames?: string[]):messageErrorType {
+export function getMyErrors (myPath: string, fieldNames?: string[], schemaPathSubstring?: string):messageErrorType {
     const { errors } = useErrors()
     const checkForInstancePath = (item: ErrorObject) => {
         return item.instancePath === myPath
+    }
+
+    const checkForSchemaPath = (item: ErrorObject) => {
+        if (schemaPathSubstring) {
+            return item.schemaPath.includes(schemaPathSubstring)
+        }
+        return true
     }
 
     const checkForArrayProblems = (item: ErrorObject) => {
@@ -55,6 +62,7 @@ export function getMyErrors (myPath: string, fieldNames?: string[]):messageError
 
     const messages = errors.value
         .filter(checkForInstancePath)
+        .filter(checkForSchemaPath)
         .filter(checkForArrayProblems)
         .filter(checkForObjectProblems)
         .filter(hideEntityErrorProblems)

--- a/src/store/validator.ts
+++ b/src/store/validator.ts
@@ -28,7 +28,11 @@ export function getMyErrors (myPath: string, fieldNames?: string[], schemaPathSu
         return true
     }
 
-    const checkForObjectProblems = (item: ErrorObject) => {
+    const checkForObjectProblems = (item: ErrorObject): boolean => {
+        // Check if the error is an errorMessage wrapper and if it is, checkForObjectProblems of any of its children
+        if (fieldNames !== undefined && item.keyword === 'errorMessage') {
+            return (item.params.errors as ErrorObject[]).some(checkForObjectProblems)
+        }
         if (fieldNames !== undefined && item.keyword === 'required') {
             return fieldNames.includes(item.params.missingProperty as string)
         }


### PR DESCRIPTION
# Pull request details

## List of related issues or pull requests

Refs:
- #380 
- #215 
- #236 

## Describe the changes made in this pull request

Proof of concept for changing error messages using `ajv-errors`.
Summary:
- An additional `errorMessage` field can be defined in the schema
- Using a separate `schema-errors.json`, we define these `errorMessage`s
- Using [`deepmerge-json`](https://www.npmjs.com/package/deepmerge-json), we merge these schemas
- `ajv` returns these new `ErrorObject`s that wrap the original `ErrorObject`s.
  - e.g., the original "title is required" error is a child of a new "Title can't be blank" error
  - Errors that are not captured by `ajv-errors` are not wrapped.
  - In a few cases, more than one `ErrorObject` is (can be) wrapped. For instance, ORCID returns two errors, one for not being an url and another for the pattern. These can be specified in more details if necessary.
- The `getMyErrors` function needed some (and may need more) modifications to handle these wrappers

We still need to handle the identifiers, but probably dealing with #369 first is better.

## Instructions to review the pull request

```shell
cd $(mktemp -d --tmpdir cffinit-pr.XXXXXX)
git clone https://github.com/citation-file-format/cff-initializer-javascript .
git checkout <this branch>
npm clean-install
npm run dev
# go to localhost:8080, see if the app works correctly
npm run lint
npm run test:unit:ci
```
