### PR TITLE
updated placement of the SchemaGuideLink hint

### DIFF
--- a/src/components/SchemaGuideLink.vue
+++ b/src/components/SchemaGuideLink.vue
@@ -10,11 +10,13 @@
             color="primary"
         />
         <q-tooltip
-            anchor="center middle"
+            anchor="center right"
             class="bg-primary text-body2 text-white"
-            self="top left"
+            self="center left"
+            transition-show="scale"
+            transition-hide="scale"
         >
-            Click to access specific documentation
+            Click the icon to access specific documentation
         </q-tooltip>
     </a>
 </template>


### PR DESCRIPTION
# Pull request details

## List of related issues or pull requests

Refs:

- #493

## Describe the changes made in this pull request

This PR updates the classes on the q-icon / q-tooltip to have better placement of the hint / so it doesnt overlap the icon. I also changed the transition to an "appear"-like one, a change from the "roll in from above"

<!-- include screenshots if that helps the review -->

Screenshot of the result:

![image](https://user-images.githubusercontent.com/4558105/168593245-42c288c2-ad05-4426-85d3-d74e45e37c14.png)


## Instructions to review the pull request

```shell
cd $(mktemp -d --tmpdir cffinit-pr.XXXXXX)
git clone https://github.com/citation-file-format/cff-initializer-javascript .
git checkout 493-hint-overlaps-icon
npm clean-install
npm run dev
# go to localhost:8080, see if the app works correctly
npm run lint
npm run test:unit:ci
```
