### PR TITLE
Add hardcode version numbers on the footer of the app and the landing page

### DIFF
--- a/README.dev.md
+++ b/README.dev.md
@@ -123,10 +123,12 @@ This section describes how to make a release in 2 parts:
 1. Verify that the information in `CITATION.cff` is correct
 2. Generate an updated version of `.zenodo.json` if needed using `cffconvert`
 3. Make sure the version field in `package.json` is correct
-4. By running `npm run lint` make sure the linter does not complain
-5. Run the unit tests with `npm run test:unit:ci`
-6. Make sure that github.io page is up to date
-7. Check whether the [Publish](https://github.com/citation-file-format/cff-initializer-javascript/actions/workflows/publish.yml) workflow worked recently and it was successful
+4. Update the version in the [landing page footer](src/components/LayoutLanding.vue).
+5. Update the version in the [app footer](src/components/Footer.vue).
+6. By running `npm run lint` make sure the linter does not complain
+7. Run the unit tests with `npm run test:unit:ci`
+8. Make sure that github.io page is up to date
+9. Check whether the [Publish](https://github.com/citation-file-format/cff-initializer-javascript/actions/workflows/publish.yml) workflow worked recently and it was successful
 
 ### (2/2) GitHub
 

--- a/src/components/Footer.vue
+++ b/src/components/Footer.vue
@@ -1,11 +1,19 @@
 <template>
-    <div id="logo">
-        <a
-            href="https://esciencecenter.nl"
-            target="_blank"
+    <div class="row">
+        <div
+            id="logo"
+            class="col"
         >
-            <img src="~assets/nlesc-logo.svg">
-        </a>
+            <a
+                href="https://esciencecenter.nl"
+                target="_blank"
+            >
+                <img src="~assets/nlesc-logo.svg">
+            </a>
+        </div>
+        <span class="col text-right text-white text-body1 text-bold">
+            Version 2.0.0
+        </span>
     </div>
 </template>
 

--- a/src/components/LayoutLanding.vue
+++ b/src/components/LayoutLanding.vue
@@ -47,22 +47,19 @@
                     />
                 </div>
             </div>
+            <span class="text-right text-black text-body1 text-bold">
+                Version 2.0.0
+            </span>
         </div>
-        <Footer />
     </div>
 </template>
 
 <script lang="ts">
-import Footer from 'components/Footer.vue'
 
 import { defineComponent } from 'vue'
 
 export default defineComponent({
     name: 'LayoutLanding',
-
-    components: {
-        Footer
-    },
 
     setup () {
         return {


### PR DESCRIPTION
# Pull request details

## List of related issues or pull requests

Refs:
- #474 

## Describe the changes made in this pull request

Adds a hardcoded version number to the footer of the app and the landing page.
Also, removes Footer from landing page.

Screenshots:

![image](https://user-images.githubusercontent.com/1068752/168813114-2f48aa4c-5147-4024-b030-3676b5a9d4d8.png)
![image](https://user-images.githubusercontent.com/1068752/168813135-5c41db6f-4e0a-4580-9c1d-4a7f9a619c0a.png)

## Instructions to review the pull request

```shell
cd $(mktemp -d --tmpdir cffinit-pr.XXXXXX)
git clone https://github.com/citation-file-format/cff-initializer-javascript .
git checkout <this branch>
npm clean-install
npm run dev
# go to localhost:8080, see if the app works correctly
npm run lint
npm run test:unit:ci
```
