### PR TITLE
Add option to check schemaPath on getMyErrors to specify identifier

### DIFF
--- a/src/components/IdentifierCardEditing.vue
+++ b/src/components/IdentifierCardEditing.vue
@@ -149,7 +149,7 @@ export default defineComponent({
             label: computed(() => linkInfo[props.type].label),
             anchor: computed(() => linkInfo[props.type].anchor),
             typeError: computed(() => getMyErrors(`/identifiers/${props.index}/type`)),
-            valueError: computed(() => getMyErrors(`/identifiers/${props.index}/value`)),
+            valueError: computed(() => getMyErrors(`/identifiers/${props.index}/value`, [], props.type)),
             descriptionError: computed(() =>
                 getMyErrors(`/identifiers/${props.index}/description`)
             ),

--- a/src/store/validator.ts
+++ b/src/store/validator.ts
@@ -7,10 +7,17 @@ export type messageErrorType = {
     messages: string[]
 }
 
-export function getMyErrors (myPath: string, fieldNames?: string[]):messageErrorType {
+export function getMyErrors (myPath: string, fieldNames?: string[], schemaPathSubstring?: string):messageErrorType {
     const { errors } = useErrors()
     const checkForInstancePath = (item: ErrorObject) => {
         return item.instancePath === myPath
+    }
+
+    const checkForSchemaPath = (item: ErrorObject) => {
+        if (schemaPathSubstring) {
+            return item.schemaPath.includes(schemaPathSubstring)
+        }
+        return true
     }
 
     const checkForArrayProblems = (item: ErrorObject) => {
@@ -55,6 +62,7 @@ export function getMyErrors (myPath: string, fieldNames?: string[]):messageError
 
     const messages = errors.value
         .filter(checkForInstancePath)
+        .filter(checkForSchemaPath)
         .filter(checkForArrayProblems)
         .filter(checkForObjectProblems)
         .filter(hideEntityErrorProblems)


### PR DESCRIPTION
# Pull request details

## List of related issues or pull requests

Refs:
- #369 

## Describe the changes made in this pull request

- Creates a new filter in `getMyErrors` so check a substring of `schemaPath`.
- Use the new filter with `IdentifiersCardEditing` to check for the type of identifier and limit the errors.

## Instructions to review the pull request

- Check the PR preview and compare it to the [main](https://cffinit.netlify.app/main) version by creating an identifier and changing the radio value.