### PR TITLE
Remove anyOf banner on identifiers

### DIFF
--- a/src/identifier-errors.ts
+++ b/src/identifier-errors.ts
@@ -12,6 +12,6 @@ export const identifierErrors = (index:number) => {
     const errors = [...myErrors, ...myChildrenErrors]
     return {
         hasError: errors.some(result => result.hasError),
-        messages: errors[0].hasError ? errors[0].messages : []
+        messages: []
     } as messageErrorType
 }


### PR DESCRIPTION
# Pull request details

## List of related issues or pull requests

Refs:
- #509 

## Describe the changes made in this pull request

Before:
![image](https://user-images.githubusercontent.com/1068752/169534560-0b3794b0-391e-4723-8501-53496578e924.png)

After:
![image](https://user-images.githubusercontent.com/1068752/169534493-8aa59ebf-8c81-4343-9676-1cd4a23e58a6.png)

`identifierErrors` was returning a single message, which would be the `anyOf` error, when present, or nothing, so this is the source of the undesired banner message. So I just return an empty array everything.

## Instructions to review the pull request

Check the preview.