### PR TITLE
add eslint rule for unused properties

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -73,6 +73,11 @@ module.exports = {
   rules: {
     'vue/v-on-style': ['error', 'longform'],
     'vue/v-bind-style': ['error', 'longform'],
+    'vue/no-unused-properties': ['error', {
+        'groups': ['props', 'data', 'computed', 'methods', 'setup'],
+        'deepData': true,
+        'ignorePublicMembers': false
+      }],
     'indent': ['error', 4],
     'vue/html-indent': ['error', 4, {
       'attribute': 1,

--- a/quasar.conf.js
+++ b/quasar.conf.js
@@ -82,7 +82,7 @@ module.exports = configure(function () {
         devServer: {
             https: false,
             port: 8080,
-            open: true // opens browser window automatically
+            open: false // do not open browser window automatically
         },
 
         // https://v2.quasar.dev/quasar-cli/quasar-conf-js#Property%3A-framework

--- a/src/components/AuthorCardEditing.vue
+++ b/src/components/AuthorCardEditing.vue
@@ -240,7 +240,7 @@ export default defineComponent({
             default: 0
         }
     },
-    setup (props) {
+    setup () {
         const givenNamesRef = ref<HTMLElement | null>(null)
         onMounted(() => {
             givenNamesRef.value?.focus()

--- a/src/components/ScreenFinishAdvanced.vue
+++ b/src/components/ScreenFinishAdvanced.vue
@@ -76,9 +76,6 @@ export default defineComponent({
                 reset()
                 setShowAdvanced(false)
                 await setStepName('start')
-            },
-            backToForm: async () => {
-                await setStepName('version-specific')
             }
         }
     }

--- a/src/components/ScreenFinishMinimum.vue
+++ b/src/components/ScreenFinishMinimum.vue
@@ -65,12 +65,10 @@ export default defineComponent({
         StepperActions
     },
     setup () {
-        const { setShowAdvanced, navigatePrevious, setStepName } = useApp()
+        const { setShowAdvanced, setStepName } = useApp()
         const { errors } = useErrors()
         return {
             isValidCFF: computed(() => errors.value.length === 0),
-            setShowAdvanced,
-            navigatePrevious,
             showAdvanced: async () => {
                 setShowAdvanced(true)
                 await setStepName('identifiers')

--- a/src/components/ScreenLicense.vue
+++ b/src/components/ScreenLicense.vue
@@ -70,7 +70,6 @@ export default defineComponent({
 
         return {
             license,
-            licenses,
             options,
             setLicense,
             licenseFilterFunction (val: string, update: (a: unknown, b: unknown) => void) {


### PR DESCRIPTION
# Pull request details

## List of related issues or pull requests

Refs: 
- #511


## Describe the changes made in this pull request

- Added eslint rule to detect unused properties
- Removed unused properties in ScreenFinishAdvanced, ScreenFinishMinimum and ScreenLicense

## Instructions to review the pull request

Run the linter with the new configuration

```shell
cd $(mktemp -d --tmpdir cffinit-pr.XXXXXX)
git clone https://github.com/citation-file-format/cff-initializer-javascript .
git checkout <this branch>
npm clean-install
npm run dev
npm run lint
```