### PR TITLE
Move navigateDirect from app to router/index to avoid inject warning

### DIFF
--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -6,7 +6,7 @@ import {
     createWebHistory
 } from 'vue-router'
 import routes from './routes'
-import { useApp, StepNameType } from '../store/app'
+import { navigateDirect, StepNameType } from 'src/store/app'
 
 /*
  * If not building with SSR mode, you can
@@ -34,7 +34,6 @@ export default route(function (/* { store, ssrContext } */) {
         )
     })
     Router.beforeEach((to) => {
-        const { navigateDirect } = useApp()
         const newStepName = to.path.replace('/', '') as StepNameType
         navigateDirect(newStepName)
     })

--- a/src/store/app.ts
+++ b/src/store/app.ts
@@ -36,6 +36,16 @@ const firstStepIndex = 0
 const lastStepIndex = computed(() => state.value.showAdvanced ? stepNames.indexOf('finish-advanced') : stepNames.indexOf('finish-minimum'))
 const stepName = computed(() => stepNames[state.value.stepIndex])
 
+export const navigateDirect = (newStepName: StepNameType) => {
+    if (!stepNames.includes(newStepName)) {
+        return
+    }
+    if (advancedStepNames.has(newStepName)) {
+        state.value.showAdvanced = true
+    }
+    state.value.stepIndex = stepNames.indexOf(newStepName)
+}
+
 export function useApp () {
     const router = useRouter()
     return {
@@ -44,15 +54,6 @@ export function useApp () {
         lastStepIndex,
         showAdvanced: computed(() => state.value.showAdvanced),
         stepName,
-        navigateDirect: (newStepName: StepNameType) => {
-            if (!stepNames.includes(newStepName)) {
-                return
-            }
-            if (advancedStepNames.has(newStepName)) {
-                state.value.showAdvanced = true
-            }
-            state.value.stepIndex = stepNames.indexOf(newStepName)
-        },
         setStepName: async (newStepName: StepNameType) => {
             state.value.stepIndex = stepNames.indexOf(newStepName)
             await router.push({ path: `/${stepName.value}` })


### PR DESCRIPTION
# Pull request details

## List of related issues or pull requests

Refs:
- #299 

## Describe the changes made in this pull request

Stop using `useApp` to avoid the inject() issue. Instead, move `navigateDirect` outside of `useApp` and export it.

## Instructions to review the pull request

- Check that the `inject` warning does not appear anymore.
- Check that you can access an advanced screen through the URL directly