### PR TITLE
now only using arrow functions

### DIFF
--- a/src/components/DownloadButton.vue
+++ b/src/components/DownloadButton.vue
@@ -15,7 +15,7 @@
 import { defineComponent, computed } from 'vue'
 import { useCffstr } from 'src/store/cffstr'
 
-function toDownloadUrl (body: string) {
+const toDownloadUrl = (body: string) => {
     return `data:text/vnd.yaml,${encodeURIComponent(body)}`
 }
 

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -17,7 +17,7 @@ import { useApp, StepNameType } from '../store/app'
  * with the Router instance.
  */
 
-export default route(function (/* { store, ssrContext } */) {
+export default route((/* { store, ssrContext } */) => {
     const createHistory = process.env.SERVER
         ? createMemoryHistory
         : (process.env.VUE_ROUTER_MODE === 'history' ? createWebHistory : createWebHashHistory)

--- a/src/store/app.ts
+++ b/src/store/app.ts
@@ -36,7 +36,7 @@ const firstStepIndex = 0
 const lastStepIndex = computed(() => state.value.showAdvanced ? stepNames.indexOf('finish-advanced') : stepNames.indexOf('finish-minimum'))
 const stepName = computed(() => stepNames[state.value.stepIndex])
 
-export function useApp () {
+export const useApp = () => {
     const router = useRouter()
     return {
         cannotGoBack: computed(() => state.value.stepIndex === firstStepIndex),

--- a/src/store/cff.ts
+++ b/src/store/cff.ts
@@ -24,7 +24,7 @@ const getInitialData = () => {
 
 const cff = ref(getInitialData())
 
-export function useCff () {
+export const useCff = () => {
     return {
         abstract: computed(() => cff.value.abstract),
         authors: computed(() => cff.value.authors),

--- a/src/store/cffstr.ts
+++ b/src/store/cffstr.ts
@@ -9,7 +9,7 @@ import { CffType } from 'src/types'
 import kebabcaseKeys from 'kebabcase-keys'
 import deepfilter from 'deep-filter'
 
-export function useCffstr () {
+export const useCffstr = () => {
     const {
         abstract,
         authors,

--- a/src/store/validation.ts
+++ b/src/store/validation.ts
@@ -12,7 +12,7 @@ ajv.addSchema(schema)
 type ajvErrorType = ErrorObject<string, Record<string, unknown>, unknown>
 const { jsObject } = useCffstr()
 
-export function useValidation () {
+export const useValidation = () => {
     return {
         errors: computed(() => {
             ajv.validate(schema.$id, jsObject.value)

--- a/src/updown.ts
+++ b/src/updown.ts
@@ -1,15 +1,15 @@
-function moveUpdate<Type> (index: number, value: number, array: Type[], updateArray: (a: Type[]) => void): void {
+const moveUpdate = <Type> (index: number, value: number, array: Type[], updateArray: (a: Type[]) => void): void => {
     const newArray: Type[] = [...array]
     newArray[index] = newArray.splice(index + value, 1, newArray[index])[0]
     updateArray(newArray)
 }
 
-export function moveDown<Type> (index: number, array: Type[], updateArray: (a: Type[]) => void): void {
+export const moveDown = <Type> (index: number, array: Type[], updateArray: (a: Type[]) => void): void => {
     if (index === array.length - 1) return
     moveUpdate(index, 1, array, updateArray)
 }
 
-export function moveUp<Type> (index: number, array: Type[], updateArray: (a: Type[]) => void): void {
+export const moveUp = <Type> (index: number, array: Type[], updateArray: (a: Type[]) => void): void => {
     if (index === 0) return
     moveUpdate(index, -1, array, updateArray)
 }


### PR DESCRIPTION
# Pull request details

## List of related issues or pull requests

Refs:

- #520

## Describe the changes made in this pull request

This PR replaces instances of `function` with arrow functions

<!-- include screenshots if that helps the review -->

## Instructions to review the pull request


```shell
cd $(mktemp -d --tmpdir cffinit-pr.XXXXXX)
git clone https://github.com/citation-file-format/cff-initializer-javascript .
git checkout 520-arrow-functions-only
npm clean-install
npm run dev
# go to localhost:8080, see if the app works correctly
npm run lint
npm run test:unit:ci
```
Everything should work exactly like on `dev`
