### PR TITLE
Remove up and down arrows from editing mode in Authors and Identifiers screens

### DIFF
--- a/src/components/AuthorCardEditing.vue
+++ b/src/components/AuthorCardEditing.vue
@@ -154,22 +154,6 @@
 
         <q-card-actions align="right">
             <q-btn
-                color="blue"
-                dense
-                v-bind:disable="index == 0"
-                icon="ion-arrow-up"
-                tabindex="-1"
-                v-on:click="$emit('moveUp')"
-            />
-            <q-btn
-                color="blue"
-                dense
-                v-bind:disable="index >= numAuthors - 1"
-                icon="ion-arrow-down"
-                tabindex="-1"
-                v-on:click="$emit('moveDown')"
-            />
-            <q-btn
                 color="negative"
                 dense
                 icon="delete"
@@ -227,10 +211,6 @@ export default defineComponent({
         orcid: {
             type: String,
             default: ''
-        },
-        numAuthors: {
-            type: Number,
-            default: 0
         }
     },
     setup (props) {
@@ -254,7 +234,7 @@ export default defineComponent({
             orcidErrors
         }
     },
-    emits: ['closePressed', 'removePressed', 'update', 'moveUp', 'moveDown'],
+    emits: ['closePressed', 'removePressed', 'update'],
     components: { SchemaGuideLink }
 })
 </script>

--- a/src/components/IdentifierCardEditing.vue
+++ b/src/components/IdentifierCardEditing.vue
@@ -56,22 +56,6 @@
         </q-card-section>
         <q-card-actions align="right">
             <q-btn
-                dense
-                color="blue"
-                v-bind:disable="index == 0"
-                icon="ion-arrow-up"
-                tabindex="-1"
-                v-on:click="$emit('moveUp')"
-            />
-            <q-btn
-                dense
-                color="blue"
-                v-bind:disable="index >= numIdentifiers - 1"
-                icon="ion-arrow-down"
-                tabindex="-1"
-                v-on:click="$emit('moveDown')"
-            />
-            <q-btn
                 color="negative"
                 dense
                 icon="delete"
@@ -113,10 +97,6 @@ export default defineComponent({
         description: {
             type: String,
             default: ''
-        },
-        numIdentifiers: {
-            type: Number,
-            default: 0
         }
     },
     components: {
@@ -155,9 +135,7 @@ export default defineComponent({
         'removePressed',
         'updateType',
         'updateValue',
-        'updateDescription',
-        'moveUp',
-        'moveDown'
+        'updateDescription'
     ]
 })
 </script>

--- a/src/components/ScreenAuthors.vue
+++ b/src/components/ScreenAuthors.vue
@@ -34,13 +34,10 @@
                         <AuthorCardEditing
                             v-else
                             v-bind:index="index"
-                            v-bind:num-authors="authors.length"
                             v-bind="author"
                             v-on:update="setAuthorField"
                             v-on:closePressed="() => (editingId = -1)"
                             v-on:removePressed="removeAuthor"
-                            v-on:moveDown="moveAuthorDown(index)"
-                            v-on:moveUp="moveAuthorUp(index)"
                         />
                     </div>
                 </div>

--- a/src/components/ScreenIdentifiers.vue
+++ b/src/components/ScreenIdentifiers.vue
@@ -35,14 +35,11 @@
                             v-else
                             v-bind:index="index"
                             v-bind="identifier"
-                            v-bind:num-identifiers="identifiers.length"
                             v-on:updateType="setIdentifierTypeField"
                             v-on:updateValue="setIdentifierValueField"
                             v-on:updateDescription="setIdentifierDescriptionField"
                             v-on:closePressed="() => (editingId = -1)"
                             v-on:removePressed="removeIdentifier"
-                            v-on:moveDown="moveIdentifierDown(index)"
-                            v-on:moveUp="moveIdentifierUp(index)"
                         />
                     </div>
                 </div>


### PR DESCRIPTION
# Pull request details

## List of related issues or pull requests

Refs:
- #405 

## Describe the changes made in this pull request

Remove up and down arrows from editing mode in Authors and Identifiers screens

## Instructions to review the pull request

- Compare against https://cffinit.netlify.app/dev and check that editing authors' and identifiers' cards don't have arrows anymore.