### PR TITLE
Change style of previous button if there is an error and user is on finish screen

### DIFF
--- a/src/components/StepperActions.vue
+++ b/src/components/StepperActions.vue
@@ -5,6 +5,7 @@
         v-bind:class="cannotGoBack ? 'hidden' : ''"
         v-bind:color="boldPrevious ? 'primary' : ''"
         v-bind:flat="!boldPrevious"
+        v-bind:unelevated="boldPrevious"
         v-on:click="navigatePrevious"
     />
     <span class="spacer" />
@@ -25,6 +26,7 @@
             color="primary"
             label="Next"
             no-caps
+            unelevated
             v-on:click="navigateNext"
         />
     </q-btn-group>

--- a/src/components/StepperActions.vue
+++ b/src/components/StepperActions.vue
@@ -1,10 +1,10 @@
 <template>
     <q-btn
-        color=""
-        flat
         label="Previous"
         no-caps
         v-bind:class="cannotGoBack ? 'hidden' : ''"
+        v-bind:color="boldPrevious ? 'primary' : ''"
+        v-bind:flat="!boldPrevious"
         v-on:click="navigatePrevious"
     />
     <span class="spacer" />
@@ -31,15 +31,19 @@
 </template>
 
 <script lang="ts">
-import { defineComponent } from 'vue'
+import { computed, defineComponent } from 'vue'
 import { useApp } from 'src/store/app'
+import { useValidation } from 'src/store/validation'
 
 export default defineComponent({
     name: 'StepperActions',
 
     setup () {
         const { showAdvanced, cannotGoBack, cannotGoForward, navigateNext, navigatePrevious } = useApp()
+        const { errors } = useValidation()
+
         return {
+            boldPrevious: computed(() => cannotGoForward.value && (errors.value.length > 0)),
             cannotGoBack,
             cannotGoForward,
             showAdvanced,


### PR DESCRIPTION
# Pull request details

## List of related issues or pull requests

Refs:
- #393 

## Describe the changes made in this pull request

Change style of previous button if we reached any of the finish screens and there is an error.
The style used is the same as the next button, so it touches `flat` and `color`.

## Instructions to review the pull request

Check the preview