### PR TITLE
Change the preview to a drawer when the screen is md or smaller

### DIFF
--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -20,6 +20,13 @@
             target="_blank"
             type="a"
         />
+        <q-btn
+            class="lt-lg"
+            icon="menu"
+            v-on:click="$emit('togglePreview')"
+        >
+            Preview
+        </q-btn>
     </q-btn-group>
 </template>
 
@@ -27,7 +34,8 @@
 import { defineComponent } from 'vue'
 
 export default defineComponent({
-    name: 'Header'
+    name: 'Header',
+    emits: ['togglePreview']
 })
 </script>
 

--- a/src/components/LayoutStepper.vue
+++ b/src/components/LayoutStepper.vue
@@ -2,7 +2,7 @@
     <q-layout view="hHh lpR fFf">
         <div id="app">
             <q-header id="header-inner">
-                <Header v-on:togglePreview="togglePreview" />
+                <Header v-on:togglePreview="onTogglePreview" />
             </q-header>
 
             <q-drawer
@@ -10,13 +10,13 @@
                 elevated
                 overlay
                 side="right"
-                v-model="previewDrawer"
+                v-model="isPreviewDrawerEnabled"
                 width="600"
             >
                 <div id="preview-button-close">
                     <q-btn
                         icon="close"
-                        v-on:click="togglePreview"
+                        v-on:click="onTogglePreview"
                     >
                         Close preview
                     </q-btn>
@@ -75,14 +75,14 @@ export default defineComponent({
         Footer
     },
     setup () {
-        const previewDrawer = ref(false)
+        const isPreviewDrawerEnabled = ref(false)
         return {
             isNotFinish: computed(() => {
                 const currentPath = useRoute().path
                 return currentPath !== '/finish-minimum' && currentPath !== '/finish-advanced'
             }),
-            previewDrawer,
-            togglePreview: () => { previewDrawer.value = !previewDrawer.value }
+            isPreviewDrawerEnabled,
+            onTogglePreview: () => { isPreviewDrawerEnabled.value = !isPreviewDrawerEnabled.value }
         }
     }
 })

--- a/src/components/LayoutStepper.vue
+++ b/src/components/LayoutStepper.vue
@@ -2,8 +2,35 @@
     <q-layout view="hHh lpR fFf">
         <div id="app">
             <q-header id="header-inner">
-                <Header />
+                <Header v-on:togglePreview="togglePreview" />
             </q-header>
+
+            <q-drawer
+                id="preview-drawer"
+                elevated
+                overlay
+                side="right"
+                v-model="previewDrawer"
+                width="600"
+            >
+                <div id="preview-button-close">
+                    <q-btn
+                        icon="close"
+                        v-on:click="togglePreview"
+                    >
+                        Close preview
+                    </q-btn>
+                </div>
+
+                <div id="preview-content">
+                    <Preview />
+                </div>
+
+                <div id="preview-button-bar">
+                    <DownloadButton v-if="isNotFinish" />
+                </div>
+            </q-drawer>
+
             <q-page-container>
                 <q-page
                     id="middle"
@@ -11,8 +38,8 @@
                 >
                     <router-view />
                     <div
-                        id="preview"
-                        class="col-12 col-md-4 col-sm-3"
+                        id="preview-static"
+                        class="col-12 col-lg-5 gt-md"
                     >
                         <div id="preview-content">
                             <Preview />
@@ -32,7 +59,7 @@
 </template>
 
 <script lang="ts">
-import { computed, defineComponent } from 'vue'
+import { computed, defineComponent, ref } from 'vue'
 import DownloadButton from 'components/DownloadButton.vue'
 import Footer from 'components/Footer.vue'
 import Header from 'components/Header.vue'
@@ -48,11 +75,14 @@ export default defineComponent({
         Footer
     },
     setup () {
+        const previewDrawer = ref(false)
         return {
             isNotFinish: computed(() => {
                 const currentPath = useRoute().path
                 return currentPath !== '/finish-minimum' && currentPath !== '/finish-advanced'
-            })
+            }),
+            previewDrawer,
+            togglePreview: () => { previewDrawer.value = !previewDrawer.value }
         }
     }
 })

--- a/src/components/ScreenAbstract.vue
+++ b/src/components/ScreenAbstract.vue
@@ -3,7 +3,7 @@
 
     <div
         id="form"
-        class="col-12 col-lg-5 col-md-4 col-sm-3"
+        class="col-12 col-lg-5 col-sm-10"
     >
         <div id="form-title">
             <h1 class="page-title">

--- a/src/components/ScreenAuthors.vue
+++ b/src/components/ScreenAuthors.vue
@@ -2,7 +2,7 @@
     <Stepper />
     <div
         id="form"
-        class="col-12 col-lg-5 col-md-4 col-sm-3"
+        class="col-12 col-lg-5 col-sm-10"
     >
         <div id="form-title">
             <h1 class="page-title">

--- a/src/components/ScreenFinishAdvanced.vue
+++ b/src/components/ScreenFinishAdvanced.vue
@@ -2,7 +2,7 @@
     <Stepper />
     <div
         id="form"
-        class="col-12 col-md-6 col-sm-7"
+        class="col-12 col-lg-5 col-sm-10"
     >
         <div id="form-title">
             <h1

--- a/src/components/ScreenFinishMinimum.vue
+++ b/src/components/ScreenFinishMinimum.vue
@@ -2,7 +2,7 @@
     <Stepper />
     <div
         id="form"
-        class="col-12 col-md-6 col-sm-7"
+        class="col-12 col-lg-5 col-sm-10"
     >
         <div id="form-title">
             <h1

--- a/src/components/ScreenIdentifiers.vue
+++ b/src/components/ScreenIdentifiers.vue
@@ -2,7 +2,7 @@
     <Stepper />
     <div
         id="form"
-        class="col-12 col-md-6 col-sm-7"
+        class="col-12 col-lg-5 col-sm-10"
     >
         <div id="form-title">
             <h1 class="page-title">

--- a/src/components/ScreenKeywords.vue
+++ b/src/components/ScreenKeywords.vue
@@ -2,7 +2,7 @@
     <Stepper />
     <div
         id="form"
-        class="col-12 col-md-6 col-sm-7"
+        class="col-12 col-lg-5 col-sm-10"
     >
         <div id="form-title">
             <h1 class="page-title">

--- a/src/components/ScreenLicense.vue
+++ b/src/components/ScreenLicense.vue
@@ -2,7 +2,7 @@
     <Stepper />
     <div
         id="form"
-        class="col-12 col-md-6 col-sm-7"
+        class="col-12 col-lg-5 col-sm-10"
     >
         <div id="form-title">
             <h1 class="page-title">

--- a/src/components/ScreenRelatedResources.vue
+++ b/src/components/ScreenRelatedResources.vue
@@ -2,7 +2,7 @@
     <Stepper />
     <div
         id="form"
-        class="col-12 col-md-6 col-sm-7"
+        class="col-12 col-lg-5 col-sm-10"
     >
         <div id="form-title">
             <h1 class="page-title">

--- a/src/components/ScreenStart.vue
+++ b/src/components/ScreenStart.vue
@@ -3,7 +3,7 @@
 
     <div
         id="form"
-        class="col-12 col-md-6 col-sm-7"
+        class="col-12 col-lg-5 col-sm-10"
     >
         <div id="form-title">
             <h1 class="page-title">

--- a/src/components/ScreenVersionSpecific.vue
+++ b/src/components/ScreenVersionSpecific.vue
@@ -2,7 +2,7 @@
     <Stepper />
     <div
         id="form"
-        class="col-12 col-md-6 col-sm-7"
+        class="col-12 col-lg-5 col-sm-10"
     >
         <div id="form-title">
             <h1 class="page-title">

--- a/src/css/app.css
+++ b/src/css/app.css
@@ -66,7 +66,7 @@ body {
     max-height: 80px;
     min-height: 80px;
 }
-#preview {
+#preview-drawer, #preview-static {
     background-color: var(--fgcolor, limegreen);
     display: flex;
     flex-direction: column;
@@ -75,6 +75,14 @@ body {
     padding-right: 30px;
     padding-top: 30px;
     border-radius: 0px 7px 7px 0px;
+}
+#preview-button-close {
+    align-items: center;
+    display: flex;
+    flex-direction: row;
+    justify-content: center;
+    max-height: 80px;
+    min-height: 80px;
 }
 #preview-content {
     background-color: var(--fgcolor, lightcoral);


### PR DESCRIPTION
# Pull request details

## List of related issues or pull requests

Refs:
- #611
- #612

## Describe the changes made in this pull request

When the screen is smaller than md size, use a overlay drawer for the cff preview instead of occupying space.
This PR consists of
- Adding a toggle button to the header when screen is md or smaller
- Adding a overlay drawer in the right right the cff preview when screen is md or smaller
- Remove the cff preview when the screen is lg or larger
- Changes many column classes for the form of each screen in adjustment to these changes (#451 would have made this easier)

## Instructions to review the pull request

Verify in the preview that the screen is responsive, that the fields are readable in half screen, and that the author edit fields are readable in half-screen. Test the toggle with different sizes.