### PR TITLE
Add check for format in related resources and identifiers and create a filter for unique

### DIFF
--- a/src/components/IdentifierCardEditing.vue
+++ b/src/components/IdentifierCardEditing.vue
@@ -73,7 +73,7 @@
 
 <script lang="ts">
 import { PropType, computed, defineComponent } from 'vue'
-import { byError, identifierValueQueries } from 'src/error-filtering'
+import { byError, identifierValueQueries, unique } from 'src/error-filtering'
 import { IdentifierTypeType } from 'src/types'
 import SchemaGuideLink from 'src/components/SchemaGuideLink.vue'
 import { useValidation } from 'src/store/validation'
@@ -116,6 +116,7 @@ export default defineComponent({
             return identifierValueQueries(props.index, ['doi', 'url', 'swh', 'other'].indexOf(props.type))
                 .filter(byError(errors.value))
                 .map(query => query.replace.message)
+                .filter(unique)
         })
         return {
             typeOptions: [

--- a/src/components/ScreenRelatedResources.vue
+++ b/src/components/ScreenRelatedResources.vue
@@ -113,7 +113,7 @@
 </template>
 
 <script lang="ts">
-import { byError, repositoryArtifactQueries, repositoryCodeQueries, repositoryQueries, urlQueries } from 'src/error-filtering'
+import { byError, repositoryArtifactQueries, repositoryCodeQueries, repositoryQueries, unique, urlQueries } from 'src/error-filtering'
 import { computed, defineComponent, onUpdated, ref } from 'vue'
 import InfoDialog from 'components/InfoDialog.vue'
 import { useCff } from 'src/store/cff'
@@ -139,21 +139,25 @@ export default defineComponent({
             return repositoryCodeQueries
                 .filter(byError(errors.value))
                 .map(query => query.replace.message)
+                .filter(unique)
         })
         const urlErrors = computed(() => {
             return urlQueries
                 .filter(byError(errors.value))
                 .map(query => query.replace.message)
+                .filter(unique)
         })
         const repositoryErrors = computed(() => {
             return repositoryQueries
                 .filter(byError(errors.value))
                 .map(query => query.replace.message)
+                .filter(unique)
         })
         const repositoryArtifactErrors = computed(() => {
             return repositoryArtifactQueries
                 .filter(byError(errors.value))
                 .map(query => query.replace.message)
+                .filter(unique)
         })
         const helpData = {
             repository: {

--- a/src/error-filtering.ts
+++ b/src/error-filtering.ts
@@ -40,6 +40,10 @@ export const byError = (errors: ErrorObject[], matcher: Comparator = defaultMatc
     }
 }
 
+export const unique = (message: string, index: number, self: string[]) => {
+    return self.indexOf(message) === index
+}
+
 export const authorsQueries: ErrorQuery[] = [{
     find: {
         instancePath: '/authors',
@@ -112,44 +116,58 @@ export const emailQueries = (index: number) => {
 }
 
 export const identifierValueQueries = (index: number, typeIndex: number) => {
-    return [[
-        {
-            find: {
-                instancePath: `/identifiers/${index}/value`,
-                schemaPath: '#/definitions/doi/pattern'
-            },
-            replace: {
-                message: 'e.g. \'10.5281/zenodo.1003149\' or \'10.7717/peerj-cs.86\'. Does not include the resolver URL.'
+    return [
+        [
+            {
+                find: {
+                    instancePath: `/identifiers/${index}/value`,
+                    schemaPath: '#/definitions/doi/pattern'
+                },
+                replace: {
+                    message: 'e.g. \'10.5281/zenodo.1003149\' or \'10.7717/peerj-cs.86\'. Does not include the resolver URL.'
+                }
             }
-        },
-        {
-            find: {
-                instancePath: `/identifiers/${index}/value`,
-                schemaPath: '#/definitions/url/pattern'
+        ], [
+            {
+                find: {
+                    instancePath: `/identifiers/${index}/value`,
+                    schemaPath: '#/definitions/url/pattern'
+                },
+                replace: {
+                    message: 'e.g. \'https://www.example.com\' (http, ftp, sftp hyperlinks are also supported)'
+                }
             },
-            replace: {
-                message: 'e.g. \'https://www.example.com\' (http, ftp, sftp hyperlinks are also supported)'
+            {
+                find: {
+                    instancePath: `/identifiers/${index}/value`,
+                    schemaPath: '#/definitions/url/format'
+                },
+                replace: {
+                    message: 'e.g. \'https://www.example.com\' (http, ftp, sftp hyperlinks are also supported)'
+                }
             }
-        },
-        {
-            find: {
-                instancePath: `/identifiers/${index}/value`,
-                schemaPath: '#/definitions/swh-identifier/pattern'
-            },
-            replace: {
-                message: 'e.g. \'swh:1:rev:309cf2674ee7a0749978cf8265ab91a60aea0f7d\'. Besides \'rev\', other allowed values are: \'snp\', \'rel\', \'dir\', and \'cnt\'.'
+        ], [
+            {
+                find: {
+                    instancePath: `/identifiers/${index}/value`,
+                    schemaPath: '#/definitions/swh-identifier/pattern'
+                },
+                replace: {
+                    message: 'e.g. \'swh:1:rev:309cf2674ee7a0749978cf8265ab91a60aea0f7d\'. Besides \'rev\', other allowed values are: \'snp\', \'rel\', \'dir\', and \'cnt\'.'
+                }
             }
-        },
-        {
-            find: {
-                instancePath: `/identifiers/${index}/value`,
-                schemaPath: '#/anyOf/3/properties/value/minLength'
-            },
-            replace: {
-                message: 'Zero-length identifier values are not allowed. Please type an identifier value or remove the identifier entirely.'
+        ], [
+            {
+                find: {
+                    instancePath: `/identifiers/${index}/value`,
+                    schemaPath: '#/anyOf/3/properties/value/minLength'
+                },
+                replace: {
+                    message: 'Zero-length identifier values are not allowed. Please type an identifier value or remove the identifier entirely.'
+                }
             }
-        }
-    ][typeIndex]] as ErrorQuery[]
+        ]
+    ][typeIndex] as ErrorQuery[]
 }
 
 export const identifiersQueries: ErrorQuery[] = [{
@@ -223,6 +241,14 @@ export const repositoryArtifactQueries: ErrorQuery[] = [{
     replace: {
         message: 'Format: https://www.example.com (http, ftp, sftp hyperlinks are also supported)'
     }
+}, {
+    find: {
+        instancePath: '/repository-artifact',
+        schemaPath: '#/definitions/url/format'
+    },
+    replace: {
+        message: 'Format: https://www.example.com (http, ftp, sftp hyperlinks are also supported)'
+    }
 }]
 
 export const repositoryCodeQueries: ErrorQuery[] = [{
@@ -233,12 +259,28 @@ export const repositoryCodeQueries: ErrorQuery[] = [{
     replace: {
         message: 'Format: https://www.example.com (http, ftp, sftp hyperlinks are also supported)'
     }
+}, {
+    find: {
+        instancePath: '/repository-code',
+        schemaPath: '#/definitions/url/format'
+    },
+    replace: {
+        message: 'Format: https://www.example.com (http, ftp, sftp hyperlinks are also supported)'
+    }
 }]
 
 export const repositoryQueries: ErrorQuery[] = [{
     find: {
         instancePath: '/repository',
         schemaPath: '#/definitions/url/pattern'
+    },
+    replace: {
+        message: 'Format: https://www.example.com (http, ftp, sftp hyperlinks are also supported)'
+    }
+}, {
+    find: {
+        instancePath: '/repository',
+        schemaPath: '#/definitions/url/format'
     },
     replace: {
         message: 'Format: https://www.example.com (http, ftp, sftp hyperlinks are also supported)'
@@ -268,6 +310,14 @@ export const urlQueries: ErrorQuery[] = [{
     find: {
         instancePath: '/url',
         schemaPath: '#/definitions/url/pattern'
+    },
+    replace: {
+        message: 'Format: https://www.example.com (http, ftp, sftp hyperlinks are also supported)'
+    }
+}, {
+    find: {
+        instancePath: '/url',
+        schemaPath: '#/definitions/url/format'
     },
     replace: {
         message: 'Format: https://www.example.com (http, ftp, sftp hyperlinks are also supported)'


### PR DESCRIPTION
# Pull request details

## List of related issues or pull requests

Refs:
- #605


## Describe the changes made in this pull request

Adds a validation check for the format of the URLs in related resources. This gets the problem with the trailing space in these URLs. We use the same error message.
Most of the time the checks for pattern and format will overlap for the related resources, and that means that there will be two errors filtered. Since these errors have the same error message, I just slice and get the first.

## Instructions to review the pull request

- Check that the error in #605 is fixed.
- Optionally, you can debug the errors and check that they are indeed different errors.