### PR TITLE
Add a mask to orcid field

### DIFF
--- a/src/components/AuthorCardEditing.vue
+++ b/src/components/AuthorCardEditing.vue
@@ -139,8 +139,8 @@
                 bg-color="white"
                 class="col"
                 dense
-                hint="Format: https://orcid.org/0000-0000-0000-0000"
-                label="orcid"
+                fill-mask
+                mask="https://orcid.org/####-####-####-###X"
                 outlined
                 standout
                 title="The person's ORCID identifier."

--- a/src/components/AuthorCardEditing.vue
+++ b/src/components/AuthorCardEditing.vue
@@ -139,7 +139,7 @@
                 bg-color="white"
                 class="col"
                 dense
-                fill-mask
+                hint="Format: https://orcid.org/0000-0000-0000-0000"
                 mask="https://orcid.org/####-####-####-###X"
                 outlined
                 standout

--- a/src/components/ScreenAuthors.vue
+++ b/src/components/ScreenAuthors.vue
@@ -121,7 +121,12 @@ export default defineComponent({
         }
         const setAuthorField = (field: keyof AuthorType, value: string) => {
             const newAuthor = { ...authors.value[editingId.value] }
-            newAuthor[field] = value === '' ? undefined : value
+            if (value === '' ||
+                (field === 'orcid' && value === 'https://orcid.org/____-____-____-____')) {
+                newAuthor[field] = undefined
+            } else {
+                newAuthor[field] = value
+            }
             authors.value[editingId.value] = newAuthor
             setAuthors(authors.value)
         }

--- a/src/components/ScreenAuthors.vue
+++ b/src/components/ScreenAuthors.vue
@@ -121,12 +121,7 @@ export default defineComponent({
         }
         const setAuthorField = (field: keyof AuthorType, value: string) => {
             const newAuthor = { ...authors.value[editingId.value] }
-            if (value === '' ||
-                (field === 'orcid' && value === 'https://orcid.org/____-____-____-____')) {
-                newAuthor[field] = undefined
-            } else {
-                newAuthor[field] = value
-            }
+            newAuthor[field] = value === '' ? undefined : value
             authors.value[editingId.value] = newAuthor
             setAuthors(authors.value)
         }


### PR DESCRIPTION
# Pull request details

## List of related issues or pull requests

Refs:
- #621
- #217 
- #186 

## Describe the changes made in this pull request

The orcid now has a mask that only permits writing the numbers (and X at the end).
To not write the mask to the cff object, I added a condition on setAuthorField.
I removed the hint and label, since they are unnecessary now.

This is the empty field:
![image](https://user-images.githubusercontent.com/1068752/185366445-b6ab797c-402c-4aa0-88cd-faf1ceef8b7b.png)

## Instructions to review the pull request

Use the preview to try to break the orcid field. Try pasting the full URL, and just the id.