### PR TITLE
Remove stepper and preview drawer button from xs screens

### DIFF
--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -21,7 +21,7 @@
             type="a"
         />
         <q-btn
-            class="lt-lg"
+            class="lt-lg gt-xs"
             icon="menu"
             v-on:click="$emit('togglePreview')"
         >

--- a/src/components/Stepper.vue
+++ b/src/components/Stepper.vue
@@ -2,7 +2,7 @@
     <q-stepper
         animated
         color="primary"
-        class="bg-secondary col-12 col-sm-2 text-primary"
+        class="bg-secondary col-12 col-sm-2 gt-xs text-primary"
         error-color="negative"
         error-icon="warning"
         flat


### PR DESCRIPTION
# Pull request details

## List of related issues or pull requests

Refs:
- #650 
- #626 (does not close, because of #613)

## Describe the changes made in this pull request

Remove the stepper and the preview button in the header when the screen is xs.

## Instructions to review the pull request

Use the preview and check the responsiveness in the dev tools.