### PR TITLE
[wip] Aggregate all helpData in a single file

### DIFF
--- a/src/components/ScreenAbstract.vue
+++ b/src/components/ScreenAbstract.vue
@@ -37,6 +37,7 @@
 <script lang="ts">
 import { defineComponent, ref } from 'vue'
 import InfoDialog from 'components/InfoDialog.vue'
+import { helpData } from 'src/store/help-data'
 import { useCff } from 'src/store/cff'
 
 export default defineComponent({
@@ -46,13 +47,6 @@ export default defineComponent({
     },
     setup () {
         const { abstract, setAbstract } = useCff()
-        const helpData = {
-            abstract: {
-                title: 'abstract',
-                url: 'https://github.com/citation-file-format/citation-file-format/blob/1.2.0/schema-guide.md#abstract',
-                description: 'A description or summary of the work.'
-            }
-        }
         return {
             abstract,
             helpData,

--- a/src/components/ScreenKeywords.vue
+++ b/src/components/ScreenKeywords.vue
@@ -67,6 +67,7 @@ import { computed, defineComponent, nextTick, onUpdated, ref } from 'vue'
 import { moveDown, moveUp } from 'src/updown'
 import InfoDialog from 'components/InfoDialog.vue'
 import Keyword from 'components/Keyword.vue'
+import { helpData } from 'src/store/help-data'
 import { scrollToBottom } from 'src/scroll-to-bottom'
 import { useCff } from 'src/store/cff'
 import { useStepperErrors } from 'src/store/stepper-errors'
@@ -120,18 +121,6 @@ export default defineComponent({
                 .filter(byError(errors.value))
                 .map(query => query.replace.message)
         })
-        const helpData = {
-            keywords: {
-                title: 'keywords',
-                url: 'https://github.com/citation-file-format/citation-file-format/blob/1.2.0/schema-guide.md#keywords',
-                description: 'Keywords that describe the work.',
-                examples: [
-                    'keyword',
-                    'other-keyword',
-                    'Yet Another Keyword'
-                ]
-            }
-        }
         return {
             addKeyword,
             keywords,

--- a/src/components/ScreenLicense.vue
+++ b/src/components/ScreenLicense.vue
@@ -50,6 +50,7 @@
 import { defineComponent, ref } from 'vue'
 import InfoDialog from 'components/InfoDialog.vue'
 import { QSelect } from 'quasar'
+import { helpData } from 'src/store/help-data'
 import schema from 'src/schemas/1.2.0/schema.json'
 import { useCff } from 'src/store/cff'
 
@@ -62,18 +63,6 @@ export default defineComponent({
         const { license, setLicense } = useCff()
         const licenses = schema.definitions['license-enum'].enum
         const options = ref(licenses)
-        const helpData = {
-            license: {
-                title: 'license',
-                url: 'https://github.com/citation-file-format/citation-file-format/blob/1.2.0/schema-guide.md#license',
-                description: 'The SPDX license identifier for the license under which the work is available.',
-                examples: [
-                    'Apache-2.0',
-                    'MIT',
-                    'GPL-3.0'
-                ]
-            }
-        }
 
         return {
             helpData,

--- a/src/components/ScreenRelatedResources.vue
+++ b/src/components/ScreenRelatedResources.vue
@@ -116,6 +116,7 @@
 import { byError, repositoryArtifactQueries, repositoryCodeQueries, repositoryQueries, urlQueries } from 'src/error-filtering'
 import { computed, defineComponent, onUpdated, ref } from 'vue'
 import InfoDialog from 'components/InfoDialog.vue'
+import { helpData } from 'src/store/help-data'
 import { useCff } from 'src/store/cff'
 import { useStepperErrors } from 'src/store/stepper-errors'
 import { useValidation } from 'src/store/validation'
@@ -155,40 +156,6 @@ export default defineComponent({
                 .filter(byError(errors.value))
                 .map(query => query.replace.message)
         })
-        const helpData = {
-            repository: {
-                title: 'repository',
-                url: 'https://github.com/citation-file-format/citation-file-format/blob/1.2.0/schema-guide.md#repository',
-                description: 'URL of the work in a repository/archive that is neither a source code repository nor a build artifact repository',
-                examples: [
-                    'https://ascl.net/2105.013'
-                ]
-            },
-            repositoryArtifact: {
-                title: 'repository-artifact',
-                url: 'https://github.com/citation-file-format/citation-file-format/blob/1.2.0/schema-guide.md#repository-artifact',
-                description: 'URL of the work in a build artifact/binary repository',
-                examples: [
-                    'https://search.maven.org/artifact/org.corpus-tools/cff-maven-plugin/0.4.0/maven-plugin'
-                ]
-            },
-            repositoryCode: {
-                title: 'repository-code',
-                url: 'https://github.com/citation-file-format/citation-file-format/blob/1.2.0/schema-guide.md#repository-code',
-                description: 'URL of the work in a source code repository',
-                examples: [
-                    'https://github.com/citation-file-format/citation-file-format'
-                ]
-            },
-            url: {
-                title: 'url',
-                url: 'https://github.com/citation-file-format/citation-file-format/blob/1.2.0/schema-guide.md#url',
-                description: 'URL of the landing page/website for the work',
-                examples: [
-                    'https://citation-file-format.github.io/'
-                ]
-            }
-        }
         return {
             helpData,
             repository,

--- a/src/components/ScreenStart.vue
+++ b/src/components/ScreenStart.vue
@@ -83,6 +83,7 @@
 import { byError, messageQueries, titleQueries } from 'src/error-filtering'
 import { computed, defineComponent, onUpdated, ref } from 'vue'
 import InfoDialog from 'components/InfoDialog.vue'
+import { helpData } from 'src/store/help-data'
 import { useCff } from 'src/store/cff'
 import { useStepperErrors } from 'src/store/stepper-errors'
 import { useValidation } from 'src/store/validation'
@@ -115,33 +116,6 @@ export default defineComponent({
             if (matches) {
                 // search and replace all occurrences
                 setMessage(message.value.split(matches[0]).join(type.value))
-            }
-        }
-        const helpData = {
-            type: {
-                title: 'type',
-                url: 'https://github.com/citation-file-format/citation-file-format/blob/1.2.0/schema-guide.md#type',
-                description: 'The type of the work that is being described by this CITATION.cff file.'
-            },
-            title: {
-                title: 'title',
-                url: 'https://github.com/citation-file-format/citation-file-format/blob/1.2.0/schema-guide.md#title',
-                description: 'The name of the software or dataset.',
-                examples: [
-                    'cffconvert',
-                    'Firefox',
-                    'LibreOffice'
-                ]
-            },
-            message: {
-                title: 'message',
-                url: 'https://github.com/citation-file-format/citation-file-format/blob/1.2.0/schema-guide.md#message',
-                description: 'A message to the human reader of the CITATION.cff file to let them know what to do with the citation metadata.',
-                examples: [
-                    'If you use this software, please cite it using the metadata from this file.',
-                    'Please cite this software using these metadata.',
-                    'Please cite this software using the metadata from "preferred-citation".'
-                ]
             }
         }
         return {

--- a/src/components/ScreenVersionSpecific.vue
+++ b/src/components/ScreenVersionSpecific.vue
@@ -115,6 +115,7 @@
 import { byError, dateReleasedQueries } from 'src/error-filtering'
 import { computed, defineComponent, onUpdated, ref } from 'vue'
 import InfoDialog from 'components/InfoDialog.vue'
+import { helpData } from 'src/store/help-data'
 import { useCff } from 'src/store/cff'
 import { useStepperErrors } from 'src/store/stepper-errors'
 import { useValidation } from 'src/store/validation'
@@ -143,32 +144,6 @@ export default defineComponent({
                 .filter(byError(errors.value))
                 .map(query => query.replace.message)
         })
-        const helpData = {
-            commit: {
-                title: 'commit',
-                url: 'https://github.com/citation-file-format/citation-file-format/blob/1.2.0/schema-guide.md#commit',
-                description: 'The commit hash or revision number of the software version.',
-                examples: [
-                    '1ff847d81f29c45a3a1a5ce73d38e45c2f319bba',
-                    'Revision: 8612'
-                ]
-            },
-            version: {
-                title: 'version',
-                url: 'https://github.com/citation-file-format/citation-file-format/blob/1.2.0/schema-guide.md#version',
-                description: 'The version of the software or dataset.',
-                examples: [
-                    '1.2.0',
-                    '1.2',
-                    '21.10 (Impish Indri)'
-                ]
-            },
-            dateReleased: {
-                title: 'date-released',
-                url: 'https://github.com/citation-file-format/citation-file-format/blob/1.2.0/schema-guide.md#date-released',
-                description: 'The date the work has been released.'
-            }
-        }
         return {
             commit,
             dateReleased,

--- a/src/store/help-data.ts
+++ b/src/store/help-data.ts
@@ -1,0 +1,108 @@
+export const helpData = {
+    abstract: {
+        title: 'abstract',
+        url: 'https://github.com/citation-file-format/citation-file-format/blob/1.2.0/schema-guide.md#abstract',
+        description: 'A description or summary of the work.'
+    },
+    commit: {
+        title: 'commit',
+        url: 'https://github.com/citation-file-format/citation-file-format/blob/1.2.0/schema-guide.md#commit',
+        description: 'The commit hash or revision number of the software version.',
+        examples: [
+            '1ff847d81f29c45a3a1a5ce73d38e45c2f319bba',
+            'Revision: 8612'
+        ]
+    },
+    dateReleased: {
+        title: 'date-released',
+        url: 'https://github.com/citation-file-format/citation-file-format/blob/1.2.0/schema-guide.md#date-released',
+        description: 'The date the work has been released.'
+    },
+    keywords: {
+        title: 'keywords',
+        url: 'https://github.com/citation-file-format/citation-file-format/blob/1.2.0/schema-guide.md#keywords',
+        description: 'Keywords that describe the work.',
+        examples: [
+            'keyword',
+            'other-keyword',
+            'Yet Another Keyword'
+        ]
+    },
+    license: {
+        title: 'license',
+        url: 'https://github.com/citation-file-format/citation-file-format/blob/1.2.0/schema-guide.md#license',
+        description: 'The SPDX license identifier for the license under which the work is available.',
+        examples: [
+            'Apache-2.0',
+            'MIT',
+            'GPL-3.0'
+        ]
+    },
+    message: {
+        title: 'message',
+        url: 'https://github.com/citation-file-format/citation-file-format/blob/1.2.0/schema-guide.md#message',
+        description: 'A message to the human reader of the CITATION.cff file to let them know what to do with the citation metadata.',
+        examples: [
+            'If you use this software, please cite it using the metadata from this file.',
+            'Please cite this software using these metadata.',
+            'Please cite this software using the metadata from "preferred-citation".'
+        ]
+    },
+    repository: {
+        title: 'repository',
+        url: 'https://github.com/citation-file-format/citation-file-format/blob/1.2.0/schema-guide.md#repository',
+        description: 'URL of the work in a repository/archive that is neither a source code repository nor a build artifact repository',
+        examples: [
+            'https://ascl.net/2105.013'
+        ]
+    },
+    repositoryArtifact: {
+        title: 'repository-artifact',
+        url: 'https://github.com/citation-file-format/citation-file-format/blob/1.2.0/schema-guide.md#repository-artifact',
+        description: 'URL of the work in a build artifact/binary repository',
+        examples: [
+            'https://search.maven.org/artifact/org.corpus-tools/cff-maven-plugin/0.4.0/maven-plugin'
+        ]
+    },
+    repositoryCode: {
+        title: 'repository-code',
+        url: 'https://github.com/citation-file-format/citation-file-format/blob/1.2.0/schema-guide.md#repository-code',
+        description: 'URL of the work in a source code repository',
+        examples: [
+            'https://github.com/citation-file-format/citation-file-format'
+        ]
+    },
+    title: {
+        title: 'title',
+        url: 'https://github.com/citation-file-format/citation-file-format/blob/1.2.0/schema-guide.md#title',
+        description: 'The name of the software or dataset.',
+        examples: [
+            'cffconvert',
+            'Firefox',
+            'LibreOffice'
+        ]
+    },
+    type: {
+        title: 'type',
+        url: 'https://github.com/citation-file-format/citation-file-format/blob/1.2.0/schema-guide.md#type',
+        description: 'The type of the work that is being described by this CITATION.cff file.'
+    },
+    url: {
+        title: 'url',
+        url: 'https://github.com/citation-file-format/citation-file-format/blob/1.2.0/schema-guide.md#url',
+        description: 'URL of the landing page/website for the work',
+        examples: [
+            'https://citation-file-format.github.io/'
+        ]
+    },
+    version: {
+        title: 'version',
+        url: 'https://github.com/citation-file-format/citation-file-format/blob/1.2.0/schema-guide.md#version',
+        description: 'The version of the software or dataset.',
+        examples: [
+            '1.2.0',
+            '1.2',
+            '21.10 (Impish Indri)'
+        ]
+    }
+}


### PR DESCRIPTION
# Pull request details

## List of related issues or pull requests

Refs:
- #673 

## Describe the changes made in this pull request

Create a file `src/store/help-data.ts` which contains all the `helpData` information.

## Instructions to review the pull request

Check in the preview that all screen info button are still working and showing the correct field.