### PR TITLE
Fix vue warning about using $ in returned property

### DIFF
--- a/src/components/DownloadButton.vue
+++ b/src/components/DownloadButton.vue
@@ -8,7 +8,7 @@
         type="a"
         download="CITATION.cff"
         v-bind:href="downloadUrl"
-        v-bind:class="$q.platform.is.mobile ? 'full-width' : ''"
+        v-bind:class="q.platform.is.mobile ? 'full-width' : ''"
     />
 </template>
 
@@ -25,9 +25,9 @@ export default defineComponent({
     name: 'DownloadButton',
     setup () {
         const { cffstr } = useCffstr()
-        const $q = useQuasar()
+        const q = useQuasar()
         return {
-            $q,
+            q,
             downloadUrl: computed(() => toDownloadUrl(cffstr.value))
         }
     }

--- a/src/components/ScreenFinishMinimum.vue
+++ b/src/components/ScreenFinishMinimum.vue
@@ -33,7 +33,7 @@
                     size="xl"
                     to="/identifiers"
                     v-on:click="showAdvanced"
-                    v-bind:class="$q.platform.is.mobile ? 'full-width' : ''"
+                    v-bind:class="q.platform.is.mobile ? 'full-width' : ''"
                 />
             </div>
         </div>
@@ -60,9 +60,9 @@ export default defineComponent({
     setup () {
         const { setShowAdvanced, setStepName } = useApp()
         const { errors } = useValidation()
-        const $q = useQuasar()
+        const q = useQuasar()
         return {
-            $q,
+            q,
             isValidCFF: computed(() => errors.value.length === 0),
             showAdvanced: async () => {
                 setShowAdvanced(true)


### PR DESCRIPTION
# Pull request details

As a contributor I confirm
- [x] I read and followed the instructions in [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] The developer documentation is up to date with the changes introduced in this Pull Request
- [x] Tests are passing
- [x] All the workflows are passing

## List of related issues or pull requests

Refs: 
- #696 


## Describe the changes made in this pull request

<!-- include screenshots if that helps the review -->


## Instructions to review the pull request

<!--

```shell
cd $(mktemp -d --tmpdir cffinit-pr.XXXXXX)
git clone https://github.com/citation-file-format/cff-initializer-javascript .
git checkout <this branch>
npm clean-install
npm run dev
# go to localhost:8080, see if the app works correctly
npm run lint
npm run test:unit:ci
```

-->
