### PR TITLE
add confirmation dialog to reset the form

### DIFF
--- a/src/components/ScreenFinishAdvanced.vue
+++ b/src/components/ScreenFinishAdvanced.vue
@@ -33,7 +33,7 @@
                     icon="refresh"
                     label="Reset form"
                     no-caps
-                    v-on:click="createAnother"
+                    v-on:click="confirmAndReset"
                 />
             </div>
         </div>
@@ -51,6 +51,7 @@ import DownloadButton from 'components/DownloadButton.vue'
 import { useApp } from 'src/store/app'
 import { useCff } from 'src/store/cff'
 import { useStepperErrors } from 'src/store/stepper-errors'
+import { useQuasar } from 'quasar'
 import { useValidation } from 'src/store/validation'
 
 export default defineComponent({
@@ -63,13 +64,21 @@ export default defineComponent({
         const { reset: resetCffData } = useCff()
         const { reset: resetStepperErrorState } = useStepperErrors()
         const { errors } = useValidation()
+        const q = useQuasar()
         return {
             isValidCFF: computed(() => errors.value.length === 0),
-            createAnother: async () => {
-                resetCffData()
-                resetStepperErrorState()
-                setShowAdvanced(false)
-                await setStepName('start')
+            confirmAndReset: async () => {
+                q.dialog({
+                    title: 'Confirm',
+                    message: 'Would you like to reset the form? All changes will be lost.',
+                    cancel: true,
+                    persistent: true
+                }).onOk(async () => {
+                    resetCffData()
+                    resetStepperErrorState()
+                    setShowAdvanced(false)
+                    await setStepName('start')
+                })
             }
         }
     }

--- a/src/components/ScreenFinishAdvanced.vue
+++ b/src/components/ScreenFinishAdvanced.vue
@@ -50,8 +50,8 @@ import { computed, defineComponent } from 'vue'
 import DownloadButton from 'components/DownloadButton.vue'
 import { useApp } from 'src/store/app'
 import { useCff } from 'src/store/cff'
-import { useStepperErrors } from 'src/store/stepper-errors'
 import { useQuasar } from 'quasar'
+import { useStepperErrors } from 'src/store/stepper-errors'
 import { useValidation } from 'src/store/validation'
 
 export default defineComponent({
@@ -67,7 +67,7 @@ export default defineComponent({
         const q = useQuasar()
         return {
             isValidCFF: computed(() => errors.value.length === 0),
-            confirmAndReset: async () => {
+            confirmAndReset: () => {
                 q.dialog({
                     title: 'Confirm',
                     message: 'Would you like to reset the form? All changes will be lost.',


### PR DESCRIPTION
# Pull request details

As a contributor I confirm
- [X] I read and followed the instructions in [CONTRIBUTING.md](CONTRIBUTING.md)
- [X] The developer documentation is up to date with the changes introduced in this Pull Request
- [X] Tests are passing
- [X] All the workflows are passing

## List of related issues or pull requests

Refs: 
- #651 


## Describe the changes made in this pull request
- Adds confirmation dialog to warn user before resetting the form. The form is reset only when user press 'OK'. Otherwise, nothing happens :)
 
<!-- include screenshots if that helps the review -->


## Instructions to review the pull request

<!--

```shell
cd $(mktemp -d --tmpdir cffinit-pr.XXXXXX)
git clone https://github.com/citation-file-format/cff-initializer-javascript .
git checkout <this branch>
npm clean-install
npm run dev
# go to localhost:8080, see if the app works correctly
npm run lint
npm run test:unit:ci
```

-->
