### PR TITLE
Adding navigation tests

### DIFF
--- a/cypress/e2e/navigation.cy.ts
+++ b/cypress/e2e/navigation.cy.ts
@@ -1,0 +1,179 @@
+import { StepNameType } from 'src/store/app'
+
+const basicStepNames = ['start', 'authors'] as Array<StepNameType>
+const advancedStepNames = [
+    'identifiers',
+    'related-resources',
+    'abstract',
+    'keywords',
+    'license',
+    'version-specific'
+] as Array<StepNameType>
+const allStepNames = [...basicStepNames, ...advancedStepNames]
+
+describe('App navigation', () => {
+    describe('during basic mode', () => {
+        it(`should have ${basicStepNames.length + 1} steps on stepper`, () => {
+            cy.visit('/start')
+            cy.get('.q-stepper__tab')
+                .should('have.length', basicStepNames.length + 1)
+        })
+        it('should allow navigation using next/previous', () => {
+            cy.visit('/start')
+            cy.get('[data-cy="btn-previous"]')
+                .should('not.be.visible')
+            basicStepNames.forEach((step) => {
+                cy.url().should('include', `/${step}`)
+                cy.get('[data-cy="btn-next"]')
+                    .click()
+                cy.get('[data-cy="btn-previous"]')
+                    .should('be.visible')
+            })
+            cy.url().should('include', '/finish-minimum')
+            cy.get('[data-cy="btn-next"]')
+                .should('not.be.visible')
+            Array.from(basicStepNames).reverse().forEach((step) => {
+                cy.get('[data-cy="btn-previous"]')
+                    .click()
+                cy.url().should('include', `/${step}`)
+                cy.get('[data-cy="btn-next"]')
+                    .should('be.visible')
+            })
+            cy.url().should('include', '/start')
+            cy.get('[data-cy="btn-previous"]')
+                .should('not.be.visible')
+        })
+        it('should be navigable through the stepper', () => {
+            ['finish-minimum', ...basicStepNames, ...[...basicStepNames].reverse()].forEach((step) => {
+                cy.visit(step === 'start' ? '/authors' : `/${step}`)
+                cy.get(`[data-cy="step-${step}"]`)
+                    .click()
+                cy.url()
+                    .should('contain', `/${step}`)
+            })
+        })
+    })
+
+    describe('during advanced mode', () => {
+        beforeEach(() => {
+            cy.visit('/start')
+            cy.get('[data-cy="input-title"]')
+                .type('A')
+            cy.visit('/authors')
+            cy.get('[data-cy="btn-add-author"]')
+                .click()
+            cy.visit('/finish-minimum')
+            cy.get('[data-cy="btn-add-more"]')
+                .click()
+        })
+        it(`should have ${allStepNames.length + 1} steps on stepper`, () => {
+            cy.visit('/start')
+            cy.get('.q-stepper__tab')
+                .should('have.length', allStepNames.length + 1)
+        })
+        it('should allow navigation using next/previous ', () => {
+            cy.visit('/start')
+            cy.get('[data-cy="btn-previous"]')
+                .should('not.be.visible')
+            allStepNames.forEach((step) => {
+                cy.url().should('include', `/${step}`)
+                cy.get('[data-cy="btn-next"]')
+                    .click()
+                cy.get('[data-cy="btn-previous"]')
+                    .should('be.visible')
+            })
+            cy.url().should('include', '/finish-advanced')
+            cy.get('[data-cy="btn-next"]')
+                .should('not.be.visible')
+            Array.from(allStepNames).reverse().forEach((step) => {
+                cy.get('[data-cy="btn-previous"]')
+                    .click()
+                cy.url().should('include', `/${step}`)
+                cy.get('[data-cy="btn-next"]')
+                    .should('be.visible')
+            })
+            cy.url().should('include', '/start')
+            cy.get('[data-cy="btn-previous"]')
+                .should('not.be.visible')
+        })
+        it('should be navigable through the stepper', () => {
+            ['finish-advanced', ...allStepNames, ...[...allStepNames].reverse()].forEach((step) => {
+                cy.visit(step === 'start' ? '/authors' : `/${step}`)
+                cy.get(`[data-cy="step-${step}"]`)
+                    .click()
+                cy.url()
+                    .should('contain', `/${step}`)
+            })
+        })
+        describe('if there are no errors', () => {
+            it('should jump from step to finish-advanced when finish is clicked', () => {
+                allStepNames.forEach((step) => {
+                    cy.visit(`/${step}`)
+                    // The next test is just to make sure the page loaded without using cy.wait
+                    cy.get('#form-title').should('not.contain', 'Congratulations')
+                    cy.get('[data-cy="btn-finish"]')
+                        .should('be.visible')
+                        .click()
+                    cy.url()
+                        .should('contain', '/finish-advanced')
+                })
+            })
+        })
+    })
+
+    describe('while navigating directly to a page', () => {
+        it(`should have ${allStepNames.length + 1} steps and visible finish/next/previous`, () => {
+            advancedStepNames.forEach((step) => {
+                cy.visit(`/${step}`)
+                cy.get('.q-stepper__tab')
+                    .should('have.length', allStepNames.length + 1)
+                cy.get('[data-cy="btn-finish"]')
+                    .should('be.visible')
+                cy.get('[data-cy="btn-next"]')
+                    .should('be.visible')
+                cy.get('[data-cy="btn-previous"]')
+                    .should('be.visible')
+            })
+        })
+        it(`should have ${basicStepNames.length + 1} steps, visible next/previous, and hidden finish`, () => {
+            basicStepNames.forEach((step) => {
+                cy.visit(`/${step}`)
+                cy.get('.q-stepper__tab')
+                    .should('have.length', basicStepNames.length + 1)
+                cy.get('[data-cy="btn-finish"]')
+                    .should('not.be.visible')
+                cy.get('[data-cy="btn-next"]')
+                    .should('be.visible')
+                if (step === 'start') {
+                    cy.get('[data-cy="btn-previous"]')
+                        .should('not.be.visible')
+                } else {
+                    cy.get('[data-cy="btn-previous"]')
+                        .should('be.visible')
+                }
+            })
+        })
+        it(`should have ${basicStepNames.length + 1} steps, visible previous, hidden next/finish for step finish-minimum`, () => {
+            cy.visit('/finish-minimum')
+            cy.get('.q-stepper__tab')
+                .should('have.length', basicStepNames.length + 1)
+            cy.get('[data-cy="btn-finish"]')
+                .should('not.be.visible')
+            cy.get('[data-cy="btn-next"]')
+                .should('not.be.visible')
+            cy.get('[data-cy="btn-previous"]')
+                .should('be.visible')
+        })
+        it(`should have ${advancedStepNames.length + 1} steps, visible previous, hidden next/finish for step finish-advanced`, () => {
+            cy.visit('/finish-advanced')
+            cy.get('.q-stepper__tab')
+                .should('have.length', allStepNames.length + 1)
+            cy.get('[data-cy="btn-finish"]')
+                .should('not.be.visible')
+            cy.get('[data-cy="btn-next"]')
+                .should('not.be.visible')
+            cy.get('[data-cy="btn-previous"]')
+                .should('be.visible')
+        })
+    })
+})

--- a/src/components/Stepper.vue
+++ b/src/components/Stepper.vue
@@ -13,6 +13,7 @@
         vertical
     >
         <q-step
+            data-cy="step-start"
             name="start"
             title="Start"
             v-bind:active-icon="errorStateScreenStart ? 'warning' : 'edit'"
@@ -22,6 +23,7 @@
         />
 
         <q-step
+            data-cy="step-authors"
             name="authors"
             title="Authors"
             v-bind:active-icon="errorStateScreenAuthors ? 'warning' : 'edit'"
@@ -32,6 +34,7 @@
 
         <q-step
             active-icon="navigate_next"
+            data-cy="step-finish-minimum"
             name="finish-minimum"
             title="Finish"
             v-bind:order="2"
@@ -40,6 +43,7 @@
         />
 
         <q-step
+            data-cy="step-identifiers"
             name="identifiers"
             title="Identifiers"
             v-bind:active-icon="errorStateScreenIdentifiers ? 'warning' : 'edit'"
@@ -50,6 +54,7 @@
         />
 
         <q-step
+            data-cy="step-related-resources"
             name="related-resources"
             title="Related resources"
             v-bind:active-icon="errorStateScreenRelatedResources ? 'warning' : 'edit'"
@@ -60,6 +65,7 @@
         />
 
         <q-step
+            data-cy="step-abstract"
             name="abstract"
             title="Abstract"
             v-bind:order="5"
@@ -68,6 +74,7 @@
         />
 
         <q-step
+            data-cy="step-keywords"
             name="keywords"
             title="Keywords"
             v-bind:active-icon="errorStateScreenKeywords ? 'warning' : 'edit'"
@@ -78,6 +85,7 @@
         />
 
         <q-step
+            data-cy="step-license"
             name="license"
             title="License"
             v-bind:order="7"
@@ -86,6 +94,7 @@
         />
 
         <q-step
+            data-cy="step-version-specific"
             name="version-specific"
             title="Version specific"
             v-bind:active-icon="errorStateScreenVersionSpecific ? 'warning' : 'edit'"
@@ -97,6 +106,7 @@
 
         <q-step
             active-icon="navigate_next"
+            data-cy="step-finish-advanced"
             name="finish-advanced"
             title="Finish"
             v-bind:order="9"

--- a/src/components/StepperActions.vue
+++ b/src/components/StepperActions.vue
@@ -1,5 +1,6 @@
 <template>
     <q-btn
+        data-cy="btn-previous"
         label="Previous"
         no-caps
         v-bind:class="cannotGoBack ? 'hidden' : ''"
@@ -16,6 +17,7 @@
     >
         <q-btn
             color=""
+            data-cy="btn-finish"
             flat
             label="Finish"
             no-caps

--- a/src/store/app.ts
+++ b/src/store/app.ts
@@ -48,7 +48,7 @@ export const useApp = () => {
             if (!stepNames.includes(newStepName)) {
                 return
             }
-            if (advancedStepNames.has(newStepName)) {
+            if (advancedStepNames.has(newStepName) || newStepName === 'finish-advanced') {
                 state.value.showAdvanced = true
             }
             state.value.stepIndex = stepNames.indexOf(newStepName)

--- a/test/jest/__tests__/store/app.jest.spec.ts
+++ b/test/jest/__tests__/store/app.jest.spec.ts
@@ -1,0 +1,134 @@
+import { StepNameType, useApp } from 'src/store/app'
+import { describe, expect, it, jest } from '@jest/globals'
+import { useCff } from 'src/store/cff'
+import { useStepperErrors } from 'src/store/stepper-errors'
+
+const routerPushMock = jest.fn()
+
+jest.mock('vue-router', () => ({
+    useRouter: () => ({
+        push: routerPushMock
+    })
+}))
+
+describe('useApp', () => {
+    const {
+        cannotGoBack,
+        cannotGoForward,
+        lastStepIndex,
+        navigateDirect,
+        navigateNext,
+        navigatePrevious,
+        setShowAdvanced,
+        setStepName,
+        showAdvanced,
+        stepName
+    } = useApp()
+    const { reset: resetCffData } = useCff()
+    const { reset: resetStepperErrorState } = useStepperErrors()
+    const basicStepNames = ['start', 'authors'] as Array<StepNameType>
+    const advancedStepNames = [
+        'identifiers',
+        'related-resources',
+        'abstract',
+        'keywords',
+        'license',
+        'version-specific'
+    ] as Array<StepNameType>
+
+    beforeEach(() => {
+        resetCffData()
+        resetStepperErrorState()
+        setShowAdvanced(false)
+        void setStepName('start')
+    })
+
+    it('should start with state on step 0 and not advanced', () => {
+        expect(showAdvanced.value).toBe(false)
+        expect(stepName.value).toBe('start')
+    })
+
+    describe('during basic mode', () => {
+        it(`should have ${basicStepNames.length} as lastIndex`, () => {
+            expect(lastStepIndex.value).toBe(basicStepNames.length)
+        })
+        it('should be navigable with next and previous (except at boundaries)', () => {
+            expect(cannotGoBack.value).toBe(true)
+            basicStepNames.forEach((step) => {
+                expect(stepName.value).toBe(step)
+                expect(cannotGoForward.value).toBe(false)
+                void navigateNext()
+                expect(cannotGoBack.value).toBe(false)
+            })
+            expect(stepName.value).toBe('finish-minimum')
+            expect(cannotGoForward.value).toBe(true)
+            Array.from(basicStepNames).reverse().forEach((step) => {
+                expect(cannotGoBack.value).toBe(false)
+                void navigatePrevious()
+                expect(stepName.value).toBe(step)
+                expect(cannotGoForward.value).toBe(false)
+            })
+            expect(stepName.value).toBe('start')
+            expect(cannotGoBack.value).toBe(true)
+        })
+    })
+
+    describe('during advanced mode', () => {
+        beforeEach(() => {
+            setShowAdvanced(true)
+        })
+        const allSteps = [...basicStepNames, ...advancedStepNames]
+        it(`should have ${allSteps.length} as lastIndex`, () => {
+            expect(lastStepIndex.value).toBe(allSteps.length + 1) // Off-by-one numbering of steps
+        })
+        it('should be navigable with next and previous (except at boundaries)', () => {
+            expect(cannotGoBack.value).toBe(true)
+            allSteps.forEach((step) => {
+                expect(stepName.value).toBe(step)
+                expect(cannotGoForward.value).toBe(false)
+                void navigateNext()
+                expect(cannotGoBack.value).toBe(false)
+            })
+            expect(stepName.value).toBe('finish-advanced')
+            expect(cannotGoForward.value).toBe(true)
+            Array.from(allSteps).reverse().forEach((step) => {
+                expect(cannotGoBack.value).toBe(false)
+                void navigatePrevious()
+                expect(stepName.value).toBe(step)
+                expect(cannotGoForward.value).toBe(false)
+            })
+            expect(stepName.value).toBe('start')
+            expect(cannotGoBack.value).toBe(true)
+        })
+    })
+
+    describe('when directly entering a path', () => {
+        beforeEach(() => {
+            setShowAdvanced(false)
+        })
+        it('should enable advanced mode for advanced steps and finish-advanced and respect next/previous', () => {
+            advancedStepNames.forEach((step) => {
+                navigateDirect(step)
+                expect(showAdvanced.value).toBe(true)
+                expect(cannotGoForward.value).toBe(false)
+                expect(cannotGoBack.value).toBe(false)
+            })
+            navigateDirect('finish-advanced')
+            expect(showAdvanced.value).toBe(true)
+            expect(cannotGoForward.value).toBe(true)
+            expect(cannotGoBack.value).toBe(false)
+        })
+        it('should not enable advanced mode for basic steps and finish-minimum and respect next/previous', () => {
+            basicStepNames.forEach((step) => {
+                navigateDirect(step)
+                expect(showAdvanced.value).toBe(false)
+                expect(cannotGoForward.value).toBe(false)
+                expect(cannotGoBack.value).toBe(step === 'start')
+            })
+            navigateDirect('finish-minimum')
+            expect(showAdvanced.value).toBe(false)
+            expect(cannotGoForward.value).toBe(true)
+            expect(cannotGoBack.value).toBe(false)
+        })
+    })
+})


### PR DESCRIPTION
# Pull request details

As a contributor I confirm
- [ ] I read and followed the instructions in [CONTRIBUTING.md](CONTRIBUTING.md)
- [ ] The developer documentation is up to date with the changes introduced in this Pull Request
- [ ] Tests are passing
- [ ] All the workflows are passing

## List of related issues or pull requests

Refs: 
- #737 
- #738 


## Describe the changes made in this pull request

<!-- include screenshots if that helps the review -->

Implements navigation tests in both Jest and Cypress.
Fix bug #738, by checking for `finish-advanced` inside `navigateDirect`.

## Instructions to review the pull request

<!--

```shell
cd $(mktemp -d --tmpdir cffinit-pr.XXXXXX)
git clone https://github.com/citation-file-format/cff-initializer-javascript .
git checkout <this branch>
npm clean-install
npm run dev
# go to localhost:8080, see if the app works correctly
npm run lint
npm run test:unit:ci
```

-->
