### PR TITLE
Remove h2 and h3 used as labels for inputs and use accessible labels for inputs

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -10,6 +10,7 @@ export default defineConfig({
 
             return config
         },
-        supportFile: 'cypress/support/index.ts'
+        supportFile: 'cypress/support/index.ts',
+        video: false
     }
 })

--- a/cypress/e2e/errors.cy.ts
+++ b/cypress/e2e/errors.cy.ts
@@ -57,6 +57,7 @@ describe('From a fixed advanced app', () => {
     })
     it('should validate screen Start', () => {
         cy.visit('/start')
+        cy.checkThatInputValidityIs(true, 'message')
         cy.dataCy('input-title')
             .clear()
         cy.checkThatStepperValidityIs(false, 'start')
@@ -69,26 +70,11 @@ describe('From a fixed advanced app', () => {
         cy.get('.q-field__messages > div')
             .should('have.length', 1)
 
-        cy.dataCy('input-message')
-            .clear()
-        cy.checkThatInputValidityIs(false, 'message')
-        cy.get('.q-field__messages > div')
-            .should('have.length', 2)
-
         cy.dataCy('input-title')
             .type('A')
         cy.findInputError('title')
             .should('not.exist')
 
-        cy.checkThatStepperValidityIs(false, 'start')
-        cy.dataCy('ta-cff-preview')
-            .should('have.class', 'error')
-        cy.dataCy('text-validation-msg')
-            .should('have.class', 'invalid')
-            .should('contain.text', 'minimum')
-
-        cy.dataCy('input-message')
-            .type('A')
         cy.checkThatInputValidityIs(true, 'message')
         cy.checkThatStepperValidityIs(true, 'start')
         cy.dataCy('ta-cff-preview')

--- a/cypress/e2e/info-dialog.cy.ts
+++ b/cypress/e2e/info-dialog.cy.ts
@@ -5,7 +5,7 @@ const infoDialogs = [
     },
     {
         screen: 'authors',
-        values: ['authors', 'given-names', 'name-particle, family-names, name-suffix', 'email', 'affiliation', 'orcid'],
+        values: ['authors', 'given-names, name-particle, family-names, name-suffix', 'email', 'affiliation', 'orcid'],
         before: () => { cy.dataCy('btn-add-author').click() }
     },
     {

--- a/cypress/e2e/spec.cy.ts
+++ b/cypress/e2e/spec.cy.ts
@@ -61,7 +61,7 @@ describe('Basic usage', () => {
             .type('My Title')
             .should('have.value', 'My Title')
         cy.dataCy('input-message')
-            .should('have.value', 'If you use this software, please cite it using the metadata from this file.')
+            .should('have.value', '')
         cy.dataCy('btn-next')
             .click()
 

--- a/src/components/AuthorCardEditing.vue
+++ b/src/components/AuthorCardEditing.vue
@@ -4,20 +4,18 @@
         bordered
         class="bg-formcard q-pa-md"
     >
-        <div class="row">
-            <h3 class="subquestion">
-                The person's given names
-                <InfoDialog name="authorGivenNames" />
-            </h3>
-        </div>
-        <div class="row">
+        <fieldset class="q-mb-md">
+            <legend>
+                Author's name, split into four parts
+                <InfoDialog name="authorNames" />
+            </legend>
             <q-input
                 autofocus
                 bg-color="white"
                 class="col"
                 data-cy="input-given-names"
                 dense
-                label="given-names"
+                label="Given names"
                 outlined
                 standout
                 v-bind:model-value="givenNames"
@@ -25,67 +23,56 @@
                 v-bind:error-message="''"
                 v-on:update:modelValue="$emit('update', 'givenNames', $event)"
             />
-        </div>
-        <div class="row">
-            <h3 class="subquestion">
-                The person's last names, split into parts
-                <InfoDialog name="authorLastNames" />
-            </h3>
-        </div>
-        <div class="row">
-            <q-input
-                bg-color="white"
-                class="col-3"
-                data-cy="input-name-particle"
-                dense
-                label="name-particle"
-                outlined
-                standout
-                v-bind:model-value="nameParticle"
-                v-bind:error="false"
-                v-bind:error-message="''"
-                v-on:update:modelValue="$emit('update', 'nameParticle', $event)"
-            />
-            <q-input
-                bg-color="white"
-                class="col"
-                data-cy="input-family-names"
-                dense
-                label="family-names"
-                outlined
-                standout
-                v-bind:model-value="familyNames"
-                v-bind:error="false"
-                v-bind:error-message="''"
-                v-on:update:modelValue="$emit('update', 'familyNames', $event)"
-            />
-            <q-input
-                bg-color="white"
-                class="col-3"
-                data-cy="input-name-suffix"
-                dense
-                label="name-suffix"
-                outlined
-                standout
-                v-bind:model-value="nameSuffix"
-                v-bind:error="false"
-                v-bind:error-message="''"
-                v-on:update:modelValue="$emit('update', 'nameSuffix', $event)"
-            />
-        </div>
-        <div class="row">
-            <h3 class="subquestion">
-                The person's email address
-                <InfoDialog name="authorEmail" />
-            </h3>
-        </div>
+            <div class="row">
+                <q-input
+                    bg-color="white"
+                    class="col-3"
+                    data-cy="input-name-particle"
+                    dense
+                    label="Name particle"
+                    outlined
+                    standout
+                    v-bind:model-value="nameParticle"
+                    v-bind:error="false"
+                    v-bind:error-message="''"
+                    v-on:update:modelValue="$emit('update', 'nameParticle', $event)"
+                />
+                <q-input
+                    bg-color="white"
+                    class="col"
+                    data-cy="input-family-names"
+                    dense
+                    label="Family names"
+                    outlined
+                    standout
+                    v-bind:model-value="familyNames"
+                    v-bind:error="false"
+                    v-bind:error-message="''"
+                    v-on:update:modelValue="$emit('update', 'familyNames', $event)"
+                />
+                <q-input
+                    bg-color="white"
+                    class="col-3"
+                    data-cy="input-name-suffix"
+                    dense
+                    label="Name suffix"
+                    outlined
+                    standout
+                    v-bind:model-value="nameSuffix"
+                    v-bind:error="false"
+                    v-bind:error-message="''"
+                    v-on:update:modelValue="$emit('update', 'nameSuffix', $event)"
+                />
+            </div>
+        </fieldset>
         <div class="row">
             <q-input
+                aria-label="E-mail. Press tab to reach help button."
                 bg-color="white"
                 class="col"
                 data-cy="input-email"
                 dense
-                label="email"
+                label="E-mail"
                 outlined
                 standout
                 type="email"
@@ -94,39 +81,39 @@
                 v-bind:error="emailErrors.length > 0"
                 v-bind:error-message="emailErrors.join(', ')"
                 v-on:update:modelValue="$emit('update', 'email', $event)"
-            />
-        </div>
-        <div class="row">
-            <h3 class="subquestion col">
-                The person's affiliation
-                <InfoDialog name="authorAffiliation" />
-            </h3>
-            <h3 class="subquestion col">
-                The person's ORCID
-                <InfoDialog name="authorOrcid" />
-            </h3>
+            >
+                <template v-slot:after>
+                    <InfoDialog name="authorEmail" />
+                </template>
+            </q-input>
         </div>
         <div class="row">
             <q-input
+                aria-label="Affiliation. Press tab to reach help button."
                 bg-color="white"
                 class="col"
                 data-cy="input-affiliation"
                 dense
-                label="affiliation"
+                label="Affiliation"
                 outlined
                 standout
                 v-bind:model-value="affiliation"
                 v-bind:error="false"
                 v-bind:error-message="''"
                 v-on:update:modelValue="$emit('update', 'affiliation', $event)"
-            />
+            >
+                <template v-slot:after>
+                    <InfoDialog name="authorAffiliation" />
+                </template>
+            </q-input>
             <q-input
+                aria-label="ORCID. Press tab to reach help button."
                 bg-color="white"
                 class="col"
                 data-cy="input-orcid"
                 dense
                 hint="Format: https://orcid.org/0000-0000-0000-0000"
-                label="orcid"
+                label="ORCID"
                 mask="https://orcid.org/####-####-####-###X"
                 outlined
                 standout
@@ -135,7 +122,11 @@
                 v-bind:error="orcidErrors.length > 0"
                 v-bind:error-message="orcidErrors.join(', ')"
                 v-on:update:modelValue="$emit('update', 'orcid', $event)"
-            />
+            >
+                <template v-slot:after>
+                    <InfoDialog name="authorOrcid" />
+                </template>
+            </q-input>
         </div>
 
         <q-card-actions align="right">

--- a/src/components/IdentifierCardEditing.vue
+++ b/src/components/IdentifierCardEditing.vue
@@ -15,49 +15,46 @@
                     v-on:update:modelValue="$emit('updateType', 'type', $event)"
                 />
             </div>
-            <div class="q-mt-md items-center no-wrap">
-                <div class="row">
-                    <h3 class="subquestion">
-                        What is the value of the {{ label }}?
-                        <InfoDialog v-bind:name="identifierType" />
-                    </h3>
-                </div>
-                <q-input
-                    autofocus
-                    bg-color="white"
-                    data-cy="input-value"
-                    label="Value"
-                    outlined
-                    standout
-                    dense
-                    v-bind:class="identifierValueErrors.length > 0 ? 'has-error' : ''"
-                    v-bind:error="identifierValueErrors.length > 0"
-                    v-bind:error-message="identifierValueErrors.join(', ')"
-                    v-bind:model-value="value"
-                    v-on:update:modelValue="$emit('updateValue', 'value', $event)"
-                />
-            </div>
-            <div class="q-mt-md items-center no-wrap">
-                <div class="row">
-                    <h3 class="subquestion">
-                        What is the description for the {{ label }}?
-                        <InfoDialog name="identifierDescription" />
-                    </h3>
-                </div>
-                <q-input
-                    bg-color="white"
-                    data-cy="input-description"
-                    label="Description"
-                    outlined
-                    standout
-                    dense
-                    v-bind:model-value="description"
-                    v-on:update:modelValue="$emit('updateDescription', 'description', $event)"
-                />
-            </div>
+
+            <q-input
+                autofocus
+                bg-color="white"
+                data-cy="input-value"
+                dense
+                outlined
+                standout
+                v-bind:aria-label="`Value of the ${label}. Press tab to reach help button.`"
+                v-bind:class="identifierValueErrors.length > 0 ? 'has-error' : ''"
+                v-bind:error-message="identifierValueErrors.join(', ')"
+                v-bind:error="identifierValueErrors.length > 0"
+                v-bind:label="`Value of the ${label}`"
+                v-bind:model-value="value"
+                v-on:update:modelValue="$emit('updateValue', 'value', $event)"
+            >
+                <template v-slot:after>
+                    <InfoDialog v-bind:name="identifierType" />
+                </template>
+            </q-input>
+
+            <q-input
+                bg-color="white"
+                data-cy="input-description"
+                dense
+                outlined
+                standout
+                v-bind:aria-label="`Description of the ${label}. Press tab to reach help button.`"
+                v-bind:label="`Description of the ${label}`"
+                v-bind:model-value="description"
+                v-on:update:modelValue="$emit('updateDescription', 'description', $event)"
+            >
+                <template v-slot:after>
+                    <InfoDialog name="identifierDescription" />
+                </template>
+            </q-input>
         </q-card-section>
         <q-card-actions align="right">
             <q-btn
+                aria-label="Remove identifier being edited"
                 color="negative"
                 data-cy="btn-remove"
                 dense
@@ -142,10 +139,3 @@ export default defineComponent({
     ]
 })
 </script>
-<style scoped>
-.row {
-  display: flex;
-  flex-direction: row;
-  column-gap: 10px;
-}
-</style>

--- a/src/components/IdentifierCardViewing.vue
+++ b/src/components/IdentifierCardViewing.vue
@@ -15,19 +15,21 @@
             <q-btn
                 class="identifier-button"
                 color="blue"
-                v-bind:data-cy="'btn-move-up' + index"
-                v-bind:disable="index == 0"
                 icon="ion-arrow-up"
                 tabindex="-1"
+                v-bind:aria-label="`Move identifier ${index + 1} up`"
+                v-bind:data-cy="'btn-move-up' + index"
+                v-bind:disable="index == 0"
                 v-on:click="$emit('moveUp')"
             />
             <q-btn
                 class="identifier-button"
                 color="blue"
-                v-bind:data-cy="'btn-move-down' + index"
-                v-bind:disable="index >= numIdentifiers - 1"
                 icon="ion-arrow-down"
                 tabindex="-1"
+                v-bind:aria-label="`Move identifier ${index + 1} down`"
+                v-bind:data-cy="'btn-move-down' + index"
+                v-bind:disable="index >= numIdentifiers - 1"
                 v-on:click="$emit('moveDown')"
             />
             <q-btn

--- a/src/components/Keyword.vue
+++ b/src/components/Keyword.vue
@@ -9,6 +9,7 @@
                 placeholder="Type a keyword"
                 v-bind:class="validationErrors.length > 0 ? 'has-error' : ''"
                 v-bind:data-cy="'input-keyword' + index"
+                v-bind:label="'Keyword #' + (index + 1)"
                 v-bind:model-value="keyword"
                 v-bind:error="validationErrors.length > 0"
                 v-bind:error-message="validationErrors.join(', ')"
@@ -18,29 +19,32 @@
         <q-btn
             class="keyword-btn"
             color="blue"
-            v-bind:data-cy="'btn-move-up' + index"
-            v-bind:disable="index == 0"
             icon="ion-arrow-up"
             tabindex="-1"
+            v-bind:aria-label="`move keyword #${index + 1} up`"
+            v-bind:data-cy="'btn-move-up' + index"
+            v-bind:disable="index == 0"
             v-on:click="$emit('moveUp')"
         />
         <q-btn
             class="keyword-btn"
             color="blue"
-            v-bind:data-cy="'btn-move-down' + index"
-            v-bind:disable="index == numKeywords - 1"
             icon="ion-arrow-down"
             tabindex="-1"
+            v-bind:aria-label="`move keyword #${index + 1} down`"
+            v-bind:data-cy="'btn-move-down' + index"
+            v-bind:disable="index == numKeywords - 1"
             v-on:click="$emit('moveDown')"
         />
         <q-btn
             class="keyword-btn"
             color="negative"
-            v-bind:data-cy="'btn-remove' + index"
             dense
             icon="delete"
             tabindex="-1"
             title="Remove"
+            v-bind:aria-label="`remove keyword #${index + 1}`"
+            v-bind:data-cy="'btn-remove' + index"
             v-on:click="$emit('removePressed')"
         />
     </div>

--- a/src/components/Preview.vue
+++ b/src/components/Preview.vue
@@ -29,12 +29,18 @@
             </q-tooltip>
         </q-btn>
     </div>
+    <label
+        for="cff-preview"
+    >
+        CITATION.cff preview
+    </label>
     <textarea
         data-cy="ta-cff-preview"
-        v-bind:class="['cffstr', isValidCFF ? '' : 'error']"
+        id="cff-preview"
         readonly="true"
-        v-bind:value="cffstr"
         wrap="hard"
+        v-bind:class="['cffstr', isValidCFF ? '' : 'error']"
+        v-bind:value="cffstr"
     />
     <div class="validation-msg">
         <p

--- a/src/components/ScreenAbstract.vue
+++ b/src/components/ScreenAbstract.vue
@@ -3,22 +3,23 @@
         Abstract
     </h1>
 
-    <h2 class="question">
-        Please provide a description of the work
-        <InfoDialog name="abstract" />
-    </h2>
     <q-input
+        aria-label="Abstract/Description of the work. Press tab to reach help button."
         autogrow
         bg-color="white"
         data-cy="input-abstract"
         input-style="min-height: 100px; max-height: 444px"
-        label="abstract"
+        label="Abstract/Description"
         outlined
         standout
         type="textarea"
         v-bind:model-value="abstract"
         v-on:update:modelValue="setAbstract"
-    />
+    >
+        <template v-slot:after>
+            <InfoDialog name="abstract" />
+        </template>
+    </q-input>
 </template>
 
 <script lang="ts">

--- a/src/components/ScreenFinish.vue
+++ b/src/components/ScreenFinish.vue
@@ -88,10 +88,10 @@ export default defineComponent({
                     message: 'Would you like to reset the form? All changes will be lost.',
                     cancel: true,
                     persistent: true
-                }).onOk(async () => {
+                }).onOk(() => {
                     resetCffData()
                     setShowAdvanced(false)
-                    await setStepName('start')
+                    void setStepName('start')
                 })
             },
             isValidCFF: computed(() => errors.value.length === 0),

--- a/src/components/ScreenLicense.vue
+++ b/src/components/ScreenLicense.vue
@@ -3,14 +3,11 @@
         License
     </h1>
 
-    <h2 class="question">
-        What is the license of the work?
-        <InfoDialog name="license" />
-    </h2>
     <q-select
+        aria-label="License. Press tab to reach help button."
         bg-color="white"
         data-cy="select-license"
-        label="license"
+        label="License"
         clearable
         fill-input
         hide-selected
@@ -29,6 +26,9 @@
                     No results
                 </q-item-section>
             </q-item>
+        </template>
+        <template v-slot:after>
+            <InfoDialog name="license" />
         </template>
     </q-select>
 </template>

--- a/src/components/ScreenRelatedResources.vue
+++ b/src/components/ScreenRelatedResources.vue
@@ -3,14 +3,11 @@
         Related resources
     </h1>
 
-    <h2 class="question">
-        What is the URL of the work in a source code repository?
-        <InfoDialog name="repositoryCode" />
-    </h2>
     <q-input
+        aria-label="Code repository. Press tab to reach help button."
         bg-color="white"
         data-cy="input-repository-code"
-        label="repository-code"
+        label="Code repository"
         outlined
         standout
         v-bind:class="repositoryCodeErrors.length > 0 ? 'has-error' : ''"
@@ -18,16 +15,17 @@
         v-bind:error="repositoryCodeErrors.length > 0"
         v-bind:error-message="repositoryCodeErrors.join(', ')"
         v-on:update:modelValue="setRepositoryCode"
-    />
+    >
+        <template v-slot:after>
+            <InfoDialog name="repositoryCode" />
+        </template>
+    </q-input>
 
-    <h2 class="question">
-        What is the URL of a landing page/website for the work?
-        <InfoDialog name="url" />
-    </h2>
     <q-input
+        aria-label="Webiste/Landing page. Press tab to reach help button."
         bg-color="white"
         data-cy="input-url"
-        label="url"
+        label="Website/Landing page"
         outlined
         standout
         v-bind:class="urlErrors.length > 0 ? 'has-error' : ''"
@@ -35,16 +33,17 @@
         v-bind:error="urlErrors.length > 0"
         v-bind:error-message="urlErrors.join(', ')"
         v-on:update:modelValue="setUrl"
-    />
+    >
+        <template v-slot:after>
+            <InfoDialog name="url" />
+        </template>
+    </q-input>
 
-    <h2 class="question">
-        What is the URL of the work in a repository?
-        <InfoDialog name="repository" />
-    </h2>
     <q-input
+        aria-label="Other repository. Press tab to reach help button."
         bg-color="white"
         data-cy="input-repository"
-        label="repository"
+        label="Other repository"
         outlined
         standout
         v-bind:class="repositoryErrors.length > 0 ? 'has-error' : ''"
@@ -52,16 +51,17 @@
         v-bind:error="repositoryErrors.length > 0"
         v-bind:error-message="repositoryErrors.join(', ')"
         v-on:update:modelValue="setRepository"
-    />
+    >
+        <template v-slot:after>
+            <InfoDialog name="repository" />
+        </template>
+    </q-input>
 
-    <h2 class="question">
-        What is the URL of the work in a build artifact/binary repository?
-        <InfoDialog name="repositoryArtifact" />
-    </h2>
     <q-input
+        aria-label="Artifact repository. Press tab to reach help button."
         bg-color="white"
         data-cy="input-repository-artifact"
-        label="repository-artifact"
+        label="Artifact repository"
         outlined
         standout
         v-bind:class="repositoryArtifactErrors.length > 0 ? 'has-error' : ''"
@@ -69,7 +69,11 @@
         v-bind:error="repositoryArtifactErrors.length > 0"
         v-bind:error-message="repositoryArtifactErrors.join(', ')"
         v-on:update:modelValue="setRepositoryArtifact"
-    />
+    >
+        <template v-slot:after>
+            <InfoDialog name="repositoryArtifact" />
+        </template>
+    </q-input>
 </template>
 
 <script lang="ts">

--- a/src/components/ScreenVersionSpecific.vue
+++ b/src/components/ScreenVersionSpecific.vue
@@ -3,81 +3,85 @@
         Version specific
     </h1>
 
-    <h2 class="question">
-        What is the commit identifier of the work?
-        <InfoDialog name="commit" />
-    </h2>
-    <q-input
-        bg-color="white"
-        data-cy="input-commit"
-        label="commit"
-        outlined
-        standout
-        v-bind:model-value="commit"
-        v-on:update:modelValue="setCommit"
-    />
+    <div class="q-gutter-md">
+        <q-input
+            aria-label="Commit identifier. Press tab to reach help button."
+            bg-color="white"
+            data-cy="input-commit"
+            label="Commit identifier"
+            outlined
+            standout
+            v-bind:model-value="commit"
+            v-on:update:modelValue="setCommit"
+        >
+            <template v-slot:after>
+                <InfoDialog name="commit" />
+            </template>
+        </q-input>
 
-    <h2 class="question">
-        What is the version of the work?
-        <InfoDialog name="version" />
-    </h2>
-    <q-input
-        bg-color="white"
-        data-cy="input-version"
-        label="version"
-        outlined
-        standout
-        v-bind:model-value="version"
-        v-on:update:modelValue="setVersion"
-    />
+        <q-input
+            aria-label="Version. Press tab to reach help button."
+            bg-color="white"
+            data-cy="input-version"
+            label="Version"
+            outlined
+            standout
+            v-bind:model-value="version"
+            v-on:update:modelValue="setVersion"
+        >
+            <template v-slot:after>
+                <InfoDialog name="version" />
+            </template>
+        </q-input>
 
-    <h2 class="question">
-        When was the version released?
-        <InfoDialog name="dateReleased" />
-    </h2>
-    <q-input
-        bg-color="white"
-        hint="Format: YYYY-MM-DD"
-        data-cy="input-date-released"
-        label="date-released"
-        mask="####-##-##"
-        outlined
-        standout
-        style="width: 33.33%"
-        today-btn="true"
-        v-bind:class="dateReleasedErrors.length > 0 ? 'has-error' : ''"
-        v-bind:model-value="dateReleased"
-        v-bind:error="dateReleasedErrors.length > 0"
-        v-bind:error-message="dateReleasedErrors.join(', ')"
-        v-on:update:modelValue="setDateReleased"
-    >
-        <template v-slot:append>
-            <q-icon
-                name="event"
-                class="cursor-pointer"
-            >
-                <q-popup-proxy
-                    transition-show="scale"
-                    transition-hide="scale"
+        <q-input
+            aria-label="Release date. Press tab to reach help button."
+            bg-color="white"
+            hint="Format: YYYY-MM-DD"
+            data-cy="input-date-released"
+            label="Release date"
+            mask="####-##-##"
+            outlined
+            standout
+            style="width: 33.33%"
+            today-btn="true"
+            v-bind:class="dateReleasedErrors.length > 0 ? 'has-error' : ''"
+            v-bind:model-value="dateReleased"
+            v-bind:error="dateReleasedErrors.length > 0"
+            v-bind:error-message="dateReleasedErrors.join(', ')"
+            v-on:update:modelValue="setDateReleased"
+        >
+            <template v-slot:append>
+                <q-icon
+                    name="event"
+                    class="cursor-pointer"
                 >
-                    <q-date
-                        v-bind:model-value="dateReleased === '' ? initializeDate() : dateReleased"
-                        v-on:update:modelValue="setDateReleased"
-                        mask="YYYY-MM-DD"
+                    <q-popup-proxy
+                        transition-show="scale"
+                        transition-hide="scale"
                     >
-                        <div class="row items-center justify-end">
-                            <q-btn
-                                v-close-popup
-                                label="Close"
-                                color="primary"
-                                flat
-                            />
-                        </div>
-                    </q-date>
-                </q-popup-proxy>
-            </q-icon>
-        </template>
-    </q-input>
+                        <q-date
+                            v-bind:model-value="dateReleased ? dateReleased : initializeDate()"
+                            v-on:update:modelValue="setDateReleased"
+                            mask="YYYY-MM-DD"
+                        >
+                            <div class="row items-center justify-end">
+                                <q-btn
+                                    v-close-popup
+                                    label="Close"
+                                    color="primary"
+                                    flat
+                                />
+                            </div>
+                        </q-date>
+                    </q-popup-proxy>
+                </q-icon>
+            </template>
+            <template v-slot:after>
+                <InfoDialog name="dateReleased" />
+            </template>
+        </q-input>
+    </div>
 </template>
 
 <script lang="ts">

--- a/src/store/help-data.ts
+++ b/src/store/help-data.ts
@@ -36,6 +36,34 @@ export const helpData = {
             'mail@research-project.org'
         ]
     },
+    authorNames: {
+        title: 'given-names, name-particle, family-names, name-suffix',
+        url: [
+            {
+                text: 'Click here to see the documentation for given-names.',
+                link: 'https://github.com/citation-file-format/citation-file-format/blob/1.2.0/schema-guide.md#definitionspersongiven-names'
+            },
+            {
+                text: 'Click here to see the documentation for name-particle.',
+                link: 'https://github.com/citation-file-format/citation-file-format/blob/1.2.0/schema-guide.md#definitionspersonname-particle'
+            },
+            {
+                text: 'Click here to see the documentation for family-name.',
+                link: 'https://github.com/citation-file-format/citation-file-format/blob/1.2.0/schema-guide.md#definitionspersonfamily-names'
+            },
+            {
+                text: 'Click here to see the documentation for name-suffix.',
+                link: 'https://github.com/citation-file-format/citation-file-format/blob/1.2.0/schema-guide.md#definitionspersonname-suffix'
+            }
+        ],
+        description: 'The person\'s full name, split into fours parts: The given names, a possible name particle, the family names, and a possible name suffix',
+        examples: [
+            'given-name: John',
+            'name-particle: von',
+            'family-name: Doe',
+            'name-suffix: Jr.'
+        ]
+    },
     authorGivenNames: {
         title: 'given-names',
         url: [


### PR DESCRIPTION
# Pull request details

As a contributor I confirm
- [ ] I read and followed the instructions in [CONTRIBUTING.md](CONTRIBUTING.md)
- [ ] The developer documentation is up to date with the changes introduced in this Pull Request
- [ ] Tests are passing
- [ ] All the workflows are passing

## List of related issues or pull requests

Refs: 
- #647


## Describe the changes made in this pull request

<!-- include screenshots if that helps the review -->
We remove most h2 and h3 (question and subquestions) that were being used as labels for inputs.
Instead, we use the input property label (and aria-label).
The default Quasar (Material) inputs have very different labels from what we have now, but they are accessible.
The alternative to this change would be creating a custom field, but that is worse for maintainability, with not enough benefits.

## Instructions to review the pull request

<!--

```shell
cd $(mktemp -d --tmpdir cffinit-pr.XXXXXX)
git clone https://github.com/citation-file-format/cff-initializer-javascript .
git checkout <this branch>
npm clean-install
npm run dev
# go to localhost:8080, see if the app works correctly
npm run lint
npm run test:unit:ci
```

-->
