### PR TITLE
Update to Quasar 2.10.1 to fix bug in ORCID field

### DIFF
--- a/cypress/e2e/specific.cy.ts
+++ b/cypress/e2e/specific.cy.ts
@@ -1,0 +1,9 @@
+describe('Issue 637 - ORCID freeze', () => {
+    it('should work when writing a full ORCID with dashes', () => {
+        cy.visit('/authors')
+        cy.dataCy('btn-add-author')
+            .click()
+        cy.dataCy('input-orcid')
+            .type('1234-1234-1234-1234')
+    })
+})

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
                 "deep-filter": "^1.0.2",
                 "js-yaml": "^3.14.1",
                 "kebabcase-keys": "^1.0.0",
-                "quasar": "^2.0.0"
+                "quasar": "^2.10.1"
             },
             "devDependencies": {
                 "@babel/eslint-parser": "^7.13.14",
@@ -18172,9 +18172,9 @@
             }
         },
         "node_modules/quasar": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/quasar/-/quasar-2.0.3.tgz",
-            "integrity": "sha512-saAyRZjPZCJE0mSBPDyfOiXIb9HkGaBQpTluTvTpNhvfcGMbwIWEnJ0fPzfnDIQqcZjbUjlSktAZrrAVayUM9Q==",
+            "version": "2.10.1",
+            "resolved": "https://registry.npmjs.org/quasar/-/quasar-2.10.1.tgz",
+            "integrity": "sha512-W0SEbTdfFS4xvO5OyTyuJent+11MpjBJUYLga69ZFigRh7SV6wFpGNfCuxAifM0L83bp4rWrL2KGoIjEoDsjOw==",
             "engines": {
                 "node": ">= 10.18.1",
                 "npm": ">= 6.13.4",
@@ -36645,9 +36645,9 @@
             "dev": true
         },
         "quasar": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/quasar/-/quasar-2.0.3.tgz",
-            "integrity": "sha512-saAyRZjPZCJE0mSBPDyfOiXIb9HkGaBQpTluTvTpNhvfcGMbwIWEnJ0fPzfnDIQqcZjbUjlSktAZrrAVayUM9Q=="
+            "version": "2.10.1",
+            "resolved": "https://registry.npmjs.org/quasar/-/quasar-2.10.1.tgz",
+            "integrity": "sha512-W0SEbTdfFS4xvO5OyTyuJent+11MpjBJUYLga69ZFigRh7SV6wFpGNfCuxAifM0L83bp4rWrL2KGoIjEoDsjOw=="
         },
         "querystring": {
             "version": "0.2.0",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
         "deep-filter": "^1.0.2",
         "js-yaml": "^3.14.1",
         "kebabcase-keys": "^1.0.0",
-        "quasar": "^2.0.0"
+        "quasar": "^2.10.1"
     },
     "devDependencies": {
         "@babel/eslint-parser": "^7.13.14",


### PR DESCRIPTION
# Pull request details

As a contributor I confirm
- [ ] I read and followed the instructions in [CONTRIBUTING.md](CONTRIBUTING.md)
- [ ] The developer documentation is up to date with the changes introduced in this Pull Request
- [ ] Tests are passing
- [ ] All the workflows are passing

## List of related issues or pull requests

Refs: 
- #637


## Describe the changes made in this pull request

<!-- include screenshots if that helps the review -->
I created a test to verify that the bug does not appear anymore. The test does not check the copy-paste version because I can't do it in Cypress.
The solution is to update to Quasar 2.10.1.

## Instructions to review the pull request

<!--

```shell
cd $(mktemp -d --tmpdir cffinit-pr.XXXXXX)
git clone https://github.com/citation-file-format/cff-initializer-javascript .
git checkout <this branch>
npm clean-install
npm run dev
# go to localhost:8080, see if the app works correctly
npm run lint
npm run test:unit:ci
```

-->
