### PR TITLE
Allow editing existing cff

### DIFF
--- a/README.dev.md
+++ b/README.dev.md
@@ -201,3 +201,29 @@ Links to documentation or tutorials related to technologies/tools we use in the 
 - [Jest](https://jestjs.io/): Testing framework to run unit tests and perform test assertions.
 - [ESLint](https://eslint.org/): To get constistent code style and prevent errors the industry standard linter ESLint is used.
 - [Majestic Web UI](https://github.com/Raathigesh/majestic): Web UI for unit tests using Jest
+
+## User stories/Requirements
+
+### Update existing CFF
+
+Constraints:
+
+- Files that were not created by cffinit should still be accepted. This implies that
+  - Fields like `preferred-citation` should be handled.
+  - Old valid files should be handled.
+- Ignore or fix small mistakes, to make the experience smoother.
+- Updating is like continuing from a finished state, so all screen should be marked as visited.
+
+Here is the list of situations that can happen:
+
+- If the input is not valid YAML, raise an error and don't proceed.
+- If the input is not an object, raise an error and don't proceed. This includes vectors and strings.
+- Keys at root level that are not part of the `cff` object are passed to `extraCffFields`. A warning is printed, but proceed.
+- Keys at nested levels (e.g., authors) are ignored. A warning is printed, but proceed.
+- Radio values ('type' and 'identifiers/type') should be sanitized.
+- If an old `cff-version` was present, warn that a newer version will be used.
+- If no `cff-version` was found, no need to warn.
+- 'date-released' should be sanitized so it is a 'yyyy-mm-dd' string, and not a Javascript date.
+- Input validation is only done a posteriori, so don't check it during update.
+- Special situations (such as `cff-version` and `type` above) should be handled explicitly and documented.
+- If parsing is successful, give positive feedback.

--- a/cypress/e2e/update.cy.ts
+++ b/cypress/e2e/update.cy.ts
@@ -1,0 +1,114 @@
+const passingCffFiles = ['passing-basic.yml', 'passing-full.yml']
+const badCffFiles = ['authors', 'cff-version', 'date-released', 'identifiers', 'type']
+
+describe('On the update screen', () => {
+    beforeEach(() => {
+        cy.visit('/update')
+    })
+    describe('Should parse passing files correctly', () => {
+        passingCffFiles.forEach((fileName) => {
+            it(`file ${fileName}`, () => {
+                cy.readFile(`cypress/e2e/yaml-examples/${fileName}`, 'binary', { timeout: 400 })
+                    .then((str) => {
+                        cy.dataCy('input-existing-cff')
+                            .invoke('val', str)
+                            .trigger('input')
+                        cy.dataCy('btn-parse')
+                            .click()
+                        cy.dataCy('text-validation-msg')
+                            .should('include.text', 'Parsed CFF successfully')
+                        cy.dataCy('btn-start')
+                            .click()
+                        cy.url().should('include', '/start')
+                        cy.dataCy('ta-cff-preview')
+                            .should('include.value', str)
+                    })
+            })
+        })
+    })
+
+    describe('Should sanitize salvageable files', () => {
+        badCffFiles.forEach((fileName) => {
+            it(`file bad-${fileName}.yml`, () => {
+                cy.readFile(`cypress/e2e/yaml-examples/bad-${fileName}.yml`, 'binary', { timeout: 400 })
+                    .then((str) => {
+                        cy.dataCy('input-existing-cff')
+                            .invoke('val', str)
+                            .trigger('input')
+                        cy.dataCy('btn-parse')
+                            .click()
+                        cy.dataCy('text-validation-msg')
+                            .should('include.text', 'Parsed CFF successfully')
+                    })
+                cy.readFile(`cypress/e2e/yaml-examples/warning-${fileName}.txt`, 'binary', { timeout: 400 })
+                    .then((str: string) => {
+                        str.split('\n').forEach((line) => {
+                            cy.dataCy('text-validation-msg')
+                                .should('include.text', line)
+                        })
+                    })
+                cy.readFile(`cypress/e2e/yaml-examples/clean-${fileName}.yml`, 'binary', { timeout: 400 })
+                    .then((str) => {
+                        cy.dataCy('btn-start')
+                            .click()
+                        cy.url().should('include', '/start')
+                        cy.dataCy('ta-cff-preview')
+                            .should('include.value', str)
+                    })
+            })
+        })
+    })
+
+    describe('Catch the following errors', () => {
+        it('should error for empty input', () => {
+            ['', '# nothing'].forEach((str) => {
+                cy.dataCy('input-existing-cff')
+                    .invoke('val', str)
+                    .trigger('input')
+                cy.dataCy('btn-parse')
+                    .click()
+                cy.dataCy('text-validation-msg')
+                    .should('include.text', 'Error: CFF is empty.')
+            })
+        })
+        it('should error for list instead of map', () => {
+            cy.dataCy('input-existing-cff')
+                .invoke('val', '- a: 1')
+                .trigger('input')
+            cy.dataCy('btn-parse')
+                .click()
+            cy.dataCy('text-validation-msg')
+                .should('include.text', 'Error: CFF is invalid. It should be a YAML map.')
+        })
+        it('should error for string instead of map', () => {
+            cy.dataCy('input-existing-cff')
+                .invoke('val', 'bad')
+                .trigger('input')
+            cy.dataCy('btn-parse')
+                .click()
+            cy.dataCy('text-validation-msg')
+                .should('include.text', 'Error: CFF is invalid. It should be a YAML map.')
+        })
+        it('should error for general invalid YAML', () => {
+            ['y : :', 'title: Software: the return'].forEach((str) => {
+                cy.dataCy('input-existing-cff')
+                    .invoke('val', str)
+                    .trigger('input')
+                cy.dataCy('btn-parse')
+                    .click()
+                cy.dataCy('text-validation-msg')
+                    .should('include.text', 'Error: could not parse CFF because of the following YAML error:')
+            })
+        })
+    })
+
+    it('should warn when fields are passed to extra', () => {
+        cy.dataCy('input-existing-cff')
+            .invoke('val', 'extra: field')
+            .trigger('input')
+        cy.dataCy('btn-parse')
+            .click()
+        cy.dataCy('text-validation-msg')
+            .should('include.text', "Property 'extra' was not identified as a basic field, so it was passed as an extra cff field")
+    })
+})

--- a/cypress/e2e/yaml-examples/bad-authors.yml
+++ b/cypress/e2e/yaml-examples/bad-authors.yml
@@ -1,0 +1,9 @@
+cff-version: 1.2.0
+title: My title
+message: >-
+  If you use this software, please cite it using the
+  metadata from this file.
+type: software
+authors:
+  - given-names: John
+    family-name: Doe

--- a/cypress/e2e/yaml-examples/bad-cff-version.yml
+++ b/cypress/e2e/yaml-examples/bad-cff-version.yml
@@ -1,0 +1,9 @@
+cff-version: 0.0.1
+title: My title
+message: >-
+  If you use this software, please cite it using the
+  metadata from this file.
+type: software
+authors:
+  - given-names: John
+    family-names: Doe

--- a/cypress/e2e/yaml-examples/bad-date-released.yml
+++ b/cypress/e2e/yaml-examples/bad-date-released.yml
@@ -1,0 +1,10 @@
+cff-version: 1.2.0
+title: My title
+message: >-
+  If you use this software, please cite it using the
+  metadata from this file.
+type: software
+authors:
+  - given-names: John
+    family-names: Doe
+date-released: 2023-01-01

--- a/cypress/e2e/yaml-examples/bad-identifiers.yml
+++ b/cypress/e2e/yaml-examples/bad-identifiers.yml
@@ -1,0 +1,16 @@
+cff-version: 1.2.0
+title: My title
+message: >-
+  If you use this software, please cite it using the
+  metadata from this file.
+type: software
+authors:
+  - given-names: John
+    family-names: Doe
+identifiers:
+  - tijpe: doi
+    describtion: 1
+  - type: dio
+    description: 2
+  - type: doi
+    description: 3

--- a/cypress/e2e/yaml-examples/bad-type.yml
+++ b/cypress/e2e/yaml-examples/bad-type.yml
@@ -1,0 +1,9 @@
+cff-version: 1.2.0
+title: My title
+message: >-
+  If you use this software, please cite it using the
+  metadata from this file.
+type: potato
+authors:
+  - given-names: John
+    family-names: Doe

--- a/cypress/e2e/yaml-examples/clean-authors.yml
+++ b/cypress/e2e/yaml-examples/clean-authors.yml
@@ -1,0 +1,8 @@
+cff-version: 1.2.0
+title: My title
+message: >-
+  If you use this software, please cite it using the
+  metadata from this file.
+type: software
+authors:
+  - given-names: John

--- a/cypress/e2e/yaml-examples/clean-cff-version.yml
+++ b/cypress/e2e/yaml-examples/clean-cff-version.yml
@@ -1,0 +1,9 @@
+cff-version: 1.2.0
+title: My title
+message: >-
+  If you use this software, please cite it using the
+  metadata from this file.
+type: software
+authors:
+  - given-names: John
+    family-names: Doe

--- a/cypress/e2e/yaml-examples/clean-date-released.yml
+++ b/cypress/e2e/yaml-examples/clean-date-released.yml
@@ -1,0 +1,10 @@
+cff-version: 1.2.0
+title: My title
+message: >-
+  If you use this software, please cite it using the
+  metadata from this file.
+type: software
+authors:
+  - given-names: John
+    family-names: Doe
+date-released: '2023-01-01'

--- a/cypress/e2e/yaml-examples/clean-identifiers.yml
+++ b/cypress/e2e/yaml-examples/clean-identifiers.yml
@@ -1,0 +1,18 @@
+cff-version: 1.2.0
+title: My title
+message: >-
+  If you use this software, please cite it using the
+  metadata from this file.
+type: software
+authors:
+  - given-names: John
+    family-names: Doe
+identifiers:
+  - type: other
+    value: ''
+  - type: other
+    value: ''
+    description: 2
+  - type: doi
+    value: ''
+    description: 3

--- a/cypress/e2e/yaml-examples/clean-type.yml
+++ b/cypress/e2e/yaml-examples/clean-type.yml
@@ -1,0 +1,9 @@
+cff-version: 1.2.0
+title: My title
+message: >-
+  If you use this software, please cite it using the
+  metadata from this file.
+type: software
+authors:
+  - given-names: John
+    family-names: Doe

--- a/cypress/e2e/yaml-examples/passing-basic.yml
+++ b/cypress/e2e/yaml-examples/passing-basic.yml
@@ -1,0 +1,9 @@
+cff-version: 1.2.0
+title: My title
+message: >-
+  If you use this software, please cite it using the
+  metadata from this file.
+type: software
+authors:
+  - given-names: John
+    family-names: Doe

--- a/cypress/e2e/yaml-examples/passing-full.yml
+++ b/cypress/e2e/yaml-examples/passing-full.yml
@@ -1,0 +1,44 @@
+cff-version: 1.2.0
+title: My Title
+message: New message
+type: dataset
+authors:
+  - given-names: John
+    name-particle: von
+    family-names: Doe
+    name-suffix: Sr.
+    email: john@doe.com
+    affiliation: UU
+    orcid: 'https://orcid.org/1234-1234-1234-123X'
+identifiers:
+  - type: doi
+    value: 10.1234/x
+    description: Some DOI
+  - type: url
+    value: 'https://id'
+    description: Some URL
+  - type: swh
+    value: 'swh:1:rev:0123456789abcdef0123456789abcdef01234567'
+    description: Some SWH
+  - type: other
+    value: Other
+    description: Some other thing
+repository-code: 'https://rc'
+url: 'https://url'
+repository: 'https://r'
+repository-artifact: 'https://ra'
+abstract: Lorem ipsum
+keywords:
+  - kw0
+  - kw1
+  - kw2
+license: Apache-2.0
+commit: '123'
+version: v1.2.3
+date-released: '2022-01-01'
+preferred-citation:
+  - authors:
+      - given-names: John
+        family-names: Doe
+    title: My Paper
+    type: article

--- a/cypress/e2e/yaml-examples/warning-authors.txt
+++ b/cypress/e2e/yaml-examples/warning-authors.txt
@@ -1,0 +1,1 @@
+Property 'family-name: Doe' inside 'authors' was ignored. Check if the key is correct.

--- a/cypress/e2e/yaml-examples/warning-cff-version.txt
+++ b/cypress/e2e/yaml-examples/warning-cff-version.txt
@@ -1,0 +1,1 @@
+cff-version was updated to 1.2.0. This might led to some issues, so verify before downloading.

--- a/cypress/e2e/yaml-examples/warning-identifiers.txt
+++ b/cypress/e2e/yaml-examples/warning-identifiers.txt
@@ -1,0 +1,2 @@
+Property 'tijpe: doi' inside 'identifiers' was ignored. Check if the key is correct.
+Invalid value 'dio' for identifier type. Using 'other' instead.

--- a/cypress/e2e/yaml-examples/warning-type.txt
+++ b/cypress/e2e/yaml-examples/warning-type.txt
@@ -1,0 +1,1 @@
+Invalid type 'potato'. Using 'software' instead.

--- a/src/components/LayoutLanding.vue
+++ b/src/components/LayoutLanding.vue
@@ -42,19 +42,34 @@
             </div>
             <div class="row justify-center items-center q-pt-md q-mb-xl">
                 <div class="column items-center slide-up-animation">
-                    <div style="font-size: 1.2rem">
-                        Create your CITATION.cff now!
+                    <div
+                        class="q-mb-md"
+                        style="font-size: 1.2rem"
+                    >
+                        Create your CITATION.cff now, or start from an existing file!
                     </div>
-                    <q-btn
-                        aria-label="Create your CITATION.cff file"
-                        class="start-button bg-primary"
-                        data-cy="btn-create"
-                        label="Create"
-                        icon="add"
-                        no-caps
-                        size="xl"
-                        to="/start"
-                    />
+                    <div class="justify-center q-gutter-md">
+                        <q-btn
+                            aria-label="Create your CITATION.cff file"
+                            class="start-button bg-primary"
+                            data-cy="btn-create"
+                            label="Create"
+                            icon="add"
+                            no-caps
+                            size="xl"
+                            to="/start"
+                        />
+                        <q-btn
+                            aria-label="Update your CITATION.cff file"
+                            class="start-button bg-primary"
+                            data-cy="btn-update"
+                            label="Update"
+                            icon="edit"
+                            no-caps
+                            size="xl"
+                            to="/update"
+                        />
+                    </div>
                 </div>
             </div>
             <span class="text-right text-black text-body1">

--- a/src/components/LayoutStepper.vue
+++ b/src/components/LayoutStepper.vue
@@ -169,19 +169,3 @@ export default defineComponent({
     }
 })
 </script>
-<style scoped>
-.skip-to-main-content-link {
-    position: absolute;
-    left: -9999px;
-    z-index: 999;
-    padding: 1em;
-    background-color: black;
-    color: white;
-    opacity: 0;
-}
-.skip-to-main-content-link:focus {
-    left: 50%;
-    transform: translateX(-50%);
-    opacity: 1;
-}
-</style>

--- a/src/components/LayoutUpdate.vue
+++ b/src/components/LayoutUpdate.vue
@@ -1,0 +1,170 @@
+<template>
+    <q-layout view="hHh lpR fFf">
+        <q-header
+            id="header"
+            class="text-black"
+        >
+            <div
+                id="skipToMain"
+            >
+                <a
+                    v-for="skipLink in skipLinks"
+                    class="skip-to-main-content-link"
+                    v-bind:key="skipLink.id"
+                    v-bind:href="`#${skipLink.id}`"
+                    v-on:blur="skipToMainFocused = false"
+                    v-on:click.prevent="focusElement(skipLink.id)"
+                    v-on:focus="skipToMainFocused = true"
+                >
+                    Skip to {{ skipLink.where }}
+                </a>
+            </div>
+            <Header />
+        </q-header>
+
+        <q-page-container>
+            <q-page
+                id="main"
+                role="main"
+                v-bind:class="isMainConnected ? '' : 'q-pa-md'"
+            >
+                <div v-bind:class="['row', 'justify-center', isMainConnected ? '' : 'q-pa-md q-ml-auto']">
+                    <div
+                        id="main-block"
+                        v-bind:class="['row', 'col', 'bg-white', 'q-pa-md', isMainConnected ? '' : 'elevated rounded-borders q-mx-lg']"
+                    >
+                        <form
+                            class="col q-gutter-md"
+                            id="form"
+                            v-on:submit.prevent
+                        >
+                            <h1
+                                id="form-title"
+                                tabindex="-1"
+                            >
+                                Update your CITATION.cff
+                            </h1>
+                            <p>
+                                Paste your CITATION.cff in the field below and click the button to start updating your CITATION.cff.
+                                The "Start editing" button will be available once a valid file is parsed.
+                            </p>
+                            <q-input
+                                autogrow
+                                data-cy="input-existing-cff"
+                                outlined
+                                label="Paste your existing CFF"
+                                type="textarea"
+                                v-model="existingCff"
+                            />
+                            <q-toolbar>
+                                <q-btn
+                                    color="primary"
+                                    data-cy="btn-parse"
+                                    icon="upload"
+                                    label="Parse"
+                                    v-on:click.prevent="parseExistingCff"
+                                />
+                                <q-space />
+                                <q-btn
+                                    color="primary"
+                                    data-cy="btn-start"
+                                    icon-right="ion-arrow-forward"
+                                    label="Start editing"
+                                    v-bind:disable="!parseSuccess"
+                                    v-on:click.prevent="startEditing"
+                                />
+                            </q-toolbar>
+                            <div data-cy="text-validation-msg">
+                                <q-item
+                                    v-for="(error, errorIndex) in existingCffError"
+                                    v-bind:key="errorIndex"
+                                >
+                                    <q-item-section side>
+                                        <q-icon
+                                            size="24px"
+                                            v-bind:color="parseSuccess ? 'accent' : 'negative'"
+                                            v-bind:name="parseSuccess ? 'warning' : 'error'"
+                                        />
+                                    </q-item-section>
+                                    <q-item-section>
+                                        <q-item-label>
+                                            {{ error }}
+                                        </q-item-label>
+                                    </q-item-section>
+                                </q-item>
+                                <q-item v-if="parseSuccess">
+                                    <q-item-section side>
+                                        <q-icon
+                                            name="done"
+                                            color="primary"
+                                            side="24px"
+                                        />
+                                    </q-item-section>
+                                    <q-item-section>
+                                        <q-item-label>
+                                            Parsed CFF successfully.
+                                        </q-item-label>
+                                    </q-item-section>
+                                </q-item>
+                            </div>
+                        </form>
+                    </div>
+                </div>
+            </q-page>
+        </q-page-container>
+
+        <q-footer id="footer">
+            <Footer />
+        </q-footer>
+    </q-layout>
+</template>
+
+<script lang="ts">
+import { computed, defineComponent, ref } from 'vue'
+import Footer from 'src/components/Footer.vue'
+import Header from 'src/components/Header.vue'
+import { updateCff } from 'src/store/cff'
+import { useApp } from 'src/store/app'
+import { useQuasar } from 'quasar'
+
+export default defineComponent({
+    name: 'LayoutUpdate',
+    components: {
+        Footer,
+        Header
+    },
+    setup () {
+        const q = useQuasar()
+        const existingCff = ref('')
+        const existingCffError = ref<string[]>([])
+        const parseSuccess = ref(false)
+        const parseExistingCff = () => {
+            const res = updateCff(existingCff.value)
+            parseSuccess.value = res.success
+            existingCffError.value = res.msg
+        }
+        const { setStepName, visitScreen } = useApp()
+
+        return {
+            existingCff,
+            existingCffError,
+            focusElement: (id: string) => {
+                const element = window.document.getElementById(id)
+                if (!element) return
+                element.focus()
+            },
+            isMainConnected: computed(() => q.screen.xs || q.screen.sm),
+            parseSuccess,
+            skipLinks: [
+                { id: 'form-title', where: 'main content' }
+            ],
+            skipToMainFocused: ref(false),
+            parseExistingCff,
+            startEditing: () => {
+                visitScreen('finish')
+                void setStepName('start')
+            }
+        }
+    }
+})
+</script>

--- a/src/css/app.css
+++ b/src/css/app.css
@@ -117,3 +117,19 @@ body {
 .red-border {
     border-color: #c10015;
 }
+
+.skip-to-main-content-link {
+    position: absolute;
+    left: -9999px;
+    z-index: 999;
+    padding: 1em;
+    background-color: black;
+    color: white;
+    opacity: 0;
+}
+
+.skip-to-main-content-link:focus {
+    left: 50%;
+    transform: translateX(-50%);
+    opacity: 1;
+}

--- a/src/router/routes.ts
+++ b/src/router/routes.ts
@@ -10,6 +10,10 @@ const routes: RouteRecordRaw[] = [
         component: () => import('src/components/LayoutLanding.vue')
     },
     {
+        path: '/update',
+        component: () => import('src/components/LayoutUpdate.vue')
+    },
+    {
         path: '/start',
         component: () => import('src/components/LayoutStepper.vue'),
         children: [{ path: '', component: () => import('src/components/ScreenStart.vue') }]

--- a/src/store/app.ts
+++ b/src/store/app.ts
@@ -81,6 +81,7 @@ export const useApp = () => {
             visitScreen(stepName.value)
             await router.push({ path: `/${stepName.value}` })
             focusFormTitle()
-        }
+        },
+        visitScreen
     }
 }

--- a/src/store/cff.ts
+++ b/src/store/cff.ts
@@ -1,5 +1,7 @@
-import { AuthorsType, CffType, IdentifiersType, KeywordsType, TypeType } from 'src/types'
+import * as yaml from 'js-yaml'
+import { AuthorType, AuthorsType, CffType, IdentifierType, IdentifierTypeType, IdentifiersType, KeywordsType, TypeType } from 'src/types'
 import { computed, ref } from 'vue'
+import camelCase from 'camelcase'
 
 const getInitialData = () => {
     return {
@@ -24,6 +26,129 @@ const getInitialData = () => {
 
 const cff = ref(getInitialData())
 const extraCffFields = ref('')
+const authorProperties = [
+    'affiliation',
+    'email',
+    'familyNames',
+    'givenNames',
+    'nameParticle',
+    'nameSuffix',
+    'orcid'
+]
+const identifierProperties = ['type', 'value', 'description']
+
+export const updateCff = (newCffstr: string) => {
+    let msg = [] as string[]
+    let success = false
+    try {
+        const existingCff = yaml.load(newCffstr)
+        extraCffFields.value = ''
+
+        if (!existingCff) {
+            throw new Error('Error: CFF is empty.')
+        } else if (Array.isArray(existingCff) || typeof existingCff === 'string') {
+            throw new Error('Error: CFF is invalid. It should be a YAML map.')
+        }
+
+        cff.value = getInitialData()
+        const existingCffProperties = Object.getOwnPropertyNames(existingCff) as Array<keyof typeof existingCff>
+        const cffProperties = Object.getOwnPropertyNames(cff.value) as Array<keyof CffType>
+        existingCffProperties.forEach((property) => {
+            const camelCaseProperty = camelCase(property) as keyof CffType
+            const value = existingCff[property]
+
+            if (cffProperties.includes(camelCaseProperty)) {
+                // Treating all special cases
+                if (property === 'type') {
+                    if (value !== 'software' && value !== 'dataset') {
+                        msg.push(`Invalid type '${value as string}'. Using 'software' instead.`)
+                        cff.value.type = 'software'
+                    } else {
+                        cff.value.type = value
+                    }
+                } else if (property === 'cff-version') {
+                    cff.value.cffVersion = '1.2.0'
+                    if (value !== '1.2.0') {
+                        msg.push('cff-version was updated to 1.2.0. This might led to some issues, so verify before downloading.')
+                    }
+                } else if (property === 'authors') {
+                    cff.value.authors = [] as AuthorsType
+
+                    const existingCffAuthors = value as Array<Record<string, string>>
+                    existingCffAuthors.forEach((existingAuthor) => {
+                        const newAuthor: AuthorType = {}
+                        Object.getOwnPropertyNames(existingAuthor)
+                            .forEach((authorProperty) => {
+                                const camelCaseAuthorProperty = camelCase(authorProperty) as keyof typeof newAuthor
+                                const value = existingAuthor[authorProperty]
+                                if (authorProperties.includes(camelCaseAuthorProperty)) {
+                                    newAuthor[camelCaseAuthorProperty] = value
+                                } else {
+                                    msg.push(`Property '${authorProperty}: ${value}' inside 'authors' was ignored. Check if the key is correct.`)
+                                }
+                            })
+                        cff.value.authors.push(newAuthor)
+                    })
+                } else if (property === 'identifiers') {
+                    cff.value.identifiers = [] as IdentifiersType
+
+                    const existingCffIdentifiers = value as Array<Record<string, string>>
+                    existingCffIdentifiers.forEach((existingIdentifier) => {
+                        const newIdentifier: IdentifierType = { type: 'other', value: '' }
+                        Object.getOwnPropertyNames(existingIdentifier)
+                            .forEach((identifierProperty) => {
+                                const camelCaseIdentifierProperty = camelCase(identifierProperty) as keyof typeof newIdentifier
+                                const value = existingIdentifier[identifierProperty]
+                                if (identifierProperties.includes(camelCaseIdentifierProperty)) {
+                                    if (camelCaseIdentifierProperty !== 'type' ||
+                                        ['doi', 'url', 'swh', 'other'].includes(value)) {
+                                        newIdentifier[camelCaseIdentifierProperty] = existingIdentifier[identifierProperty] as IdentifierTypeType
+                                    } else if (camelCaseIdentifierProperty === 'type') {
+                                        msg.push(`Invalid value '${value}' for identifier type. Using 'other' instead.`)
+                                        newIdentifier.type = 'other'
+                                    }
+                                } else {
+                                    msg.push(`Property '${identifierProperty}: ${value}' inside 'identifiers' was ignored. Check if the key is correct.`)
+                                }
+                            })
+                        cff.value.identifiers?.push(newIdentifier)
+                    })
+                } else if (property === 'date-released') {
+                    const value = existingCff[property]
+                    if (typeof value === 'string') {
+                        cff.value.dateReleased = value
+                    } else {
+                        cff.value.dateReleased = (value as Date).toISOString().slice(0, 10)
+                    }
+                } else {
+                    // No special treatment, just add to cff
+                    cff.value[camelCaseProperty] = existingCff[property]
+                }
+            } else {
+                // Existing CFF property is not part of cff, so add it to extra
+                const thisYamlElement = {}
+                thisYamlElement[property] = existingCff[property]
+                extraCffFields.value += yaml.dump(thisYamlElement)
+                msg.push(`Property '${property as string}' was not identified as a basic field, so it was passed as an extra cff field.`)
+            }
+        })
+
+        success = true
+    } catch (error) {
+        if (error instanceof yaml.YAMLException) {
+            msg = ['Error: could not parse CFF because of the following YAML error: ' + error.message]
+        } else if (error instanceof Error) {
+            msg = [error.message]
+        } else {
+            msg = ['Uncaught error. Please report this issue.']
+        }
+    }
+
+    return {
+        success,
+        msg
+    }
+}
 
 export const useCff = () => {
     return {

--- a/test/jest/__tests__/store/cffupdate.jest.spec.ts
+++ b/test/jest/__tests__/store/cffupdate.jest.spec.ts
@@ -1,0 +1,167 @@
+import * as yaml from 'js-yaml'
+import { beforeEach, describe, expect, it } from '@jest/globals'
+import { updateCff, useCff } from 'src/store/cff'
+import { useCffstr } from 'src/store/cffstr'
+
+describe('Update of existing CFF', () => {
+    const cff = useCff()
+    const { cffstr } = useCffstr()
+    const parsedCffStr = () => { return yaml.load(cffstr.value) }
+    const cffMinimumFields = {
+        'cff-version': '1.2.0',
+        type: 'software',
+        title: '',
+        message: 'If you use this software, please cite it using the metadata from this file.',
+        authors: []
+    }
+    const cffstrFields = [
+        { field: 'abstract', value: 'Description' },
+        {
+            field: 'authors',
+            value: [
+                {
+                    'given-names': 'John',
+                    'family-names': 'Doe',
+                    orcid: 'https://1234-1234-1234-123X',
+                    email: 'john@doe.com'
+                }
+            ]
+        },
+        { field: 'commit', value: '1234567890abcde' },
+        { field: 'date-released', value: '2022-01-01' },
+        { field: 'identifiers', value: [{ type: 'doi', value: '10.5281/zenodo.5171937' }] },
+        { field: 'keywords', value: ['kw1', 'kw2'] },
+        { field: 'license', value: 'Apache-2.0' },
+        { field: 'message', value: 'Cite me!' },
+        { field: 'repository-artifact', value: 'https://a' },
+        { field: 'repository-code', value: 'https://a' },
+        { field: 'repository', value: 'https://a' },
+        { field: 'title', value: 'Title' },
+        { field: 'type', value: 'dataset' },
+        { field: 'url', value: 'https://a' },
+        { field: 'version', value: '1.2.3' },
+        {
+            field: 'preferred-citation',
+            value: {
+                authors: [{ 'given-names': 'John', 'family-names': 'Doe' }],
+                title: 'The paper',
+                type: 'article'
+            }
+        }
+    ]
+
+    beforeEach(() => {
+        cff.reset()
+    })
+    describe('Should returns errors for', () => {
+        test('empty field', () => {
+            expect(updateCff('')).toEqual({ msg: ['Error: CFF is empty.'], success: false })
+        })
+        test('array instead of list', () => {
+            expect(updateCff('- a\n- b\n- c')).toEqual({
+                msg: ['Error: CFF is invalid. It should be a YAML map.'],
+                success: false
+            })
+        })
+        test('string instead of list', () => {
+            expect(updateCff('bad')).toEqual({
+                msg: ['Error: CFF is invalid. It should be a YAML map.'],
+                success: false
+            })
+        })
+        test('catch YAML errors', () => {
+            const { msg, success } = updateCff('a: -')
+            expect(msg[0]).toContain('Error: could not parse CFF because of the following YAML error:')
+            expect(success).toBe(false)
+        })
+    })
+    it('should work for the minimum information', () => {
+        expect(updateCff('cff-version: 1.2.0')).toEqual({ msg: [], success: true })
+        expect(parsedCffStr()).toEqual(cffMinimumFields)
+    })
+    it('should work for full cff', () => {
+        let expected = { ...cffMinimumFields }
+        for (const fieldData of cffstrFields) {
+            const { field, value } = fieldData
+            expected = { ...expected, [field]: value }
+        }
+        const updateStr = yaml.dump(cffstrFields.reduce((acc, { field, value }) => {
+            return { ...acc, [field]: value }
+        }, {}))
+        const { msg, success } = updateCff(updateStr)
+        expect(msg).toHaveLength(1)
+        expect(msg[0]).toBe("Property 'preferred-citation' was not identified as a basic field, so it was passed as an extra cff field.")
+        expect(success).toBe(true)
+        expect(parsedCffStr()).toEqual(expected)
+    })
+    describe('should work for each field of a full cff', () => {
+        for (const fieldData of cffstrFields) {
+            const { field, value } = fieldData
+            test(`field ${field}`, () => {
+                const expected = { ...cffMinimumFields, [field]: value }
+                const { msg, success } = updateCff(yaml.dump({ [field]: value }))
+                expect(msg).toHaveLength(field === 'preferred-citation' ? 1 : 0)
+                expect(success).toBe(true)
+                expect(parsedCffStr()).toEqual(expected)
+            })
+        }
+    })
+    test('keys at root level that are not part of the part of cff are kept as extra', () => {
+        const { msg, success } = updateCff('bad: value')
+        expect(msg).toHaveLength(1)
+        expect(msg[0]).toBe("Property 'bad' was not identified as a basic field, so it was passed as an extra cff field.")
+        expect(success).toBe(true)
+        const expected = { ...cffMinimumFields, bad: 'value' }
+        expect(parsedCffStr()).toEqual(expected)
+    })
+    test('keys at authors level that are not part of the part of cff are ignored', () => {
+        const { msg, success } = updateCff('authors:\n- bad: value')
+        expect(msg).toHaveLength(1)
+        expect(msg[0]).toBe("Property 'bad: value' inside 'authors' was ignored. Check if the key is correct.")
+        expect(success).toBe(true)
+        const expected = { ...cffMinimumFields, authors: [{}] }
+        expect(parsedCffStr()).toEqual(expected)
+    })
+    test('keys at identifiers level that are not part of the part of cff are ignored', () => {
+        const { msg, success } = updateCff('identifiers:\n- bad: value')
+        expect(msg).toHaveLength(1)
+        expect(msg[0]).toBe("Property 'bad: value' inside 'identifiers' was ignored. Check if the key is correct.")
+        expect(success).toBe(true)
+        const expected = { ...cffMinimumFields, identifiers: [{ type: 'other', value: '' }] }
+        expect(parsedCffStr()).toEqual(expected)
+    })
+    test('type should be software or dataset', () => {
+        const { msg, success } = updateCff('type: potato')
+        expect(msg).toHaveLength(1)
+        expect(msg[0]).toBe("Invalid type 'potato'. Using 'software' instead.")
+        expect(success).toBe(true)
+        expect(parsedCffStr()).toEqual(cffMinimumFields)
+    })
+    test('identifier type should be valid', () => {
+        const { msg, success } = updateCff('identifiers:\n- type: potato\n  value: fried')
+        expect(msg).toHaveLength(1)
+        expect(msg[0]).toBe("Invalid value 'potato' for identifier type. Using 'other' instead.")
+        expect(success).toBe(true)
+        const expected = { ...cffMinimumFields, identifiers: [{ type: 'other', value: 'fried' }] }
+        expect(parsedCffStr()).toEqual(expected)
+    })
+    test('fix old cff-version', () => {
+        const { msg, success } = updateCff('cff-version: 0.0.1')
+        expect(msg).toHaveLength(1)
+        expect(msg[0]).toBe('cff-version was updated to 1.2.0. This might led to some issues, so verify before downloading.')
+        expect(success).toBe(true)
+        expect(parsedCffStr()).toEqual(cffMinimumFields)
+    })
+    test('date-released should work for non-string', () => {
+        const { msg, success } = updateCff('date-released: 2023-01-01')
+        expect(msg).toHaveLength(0)
+        expect(success).toBe(true)
+        const expected = { ...cffMinimumFields, 'date-released': '2023-01-01' }
+        expect(parsedCffStr()).toEqual(expected)
+    })
+    test('ignore bad values validated a posteriori', () => {
+        const { msg, success } = updateCff("title: ''\nmessage: ''\nauthors: [{ orcid: bad }, { orcid: bad }]\nidentifiers:\n- type: doi\n  value: bad")
+        expect(msg).toHaveLength(0)
+        expect(success).toBe(true)
+    })
+})


### PR DESCRIPTION
# Pull request details

As a contributor I confirm
- [ ] I read and followed the instructions in [CONTRIBUTING.md](CONTRIBUTING.md)
- [ ] The developer documentation is up to date with the changes introduced in this Pull Request
- [ ] Tests are passing
- [ ] All the workflows are passing

## List of related issues or pull requests

Refs: 
- #814
- #813 

## Describe the changes made in this pull request

<!-- include screenshots if that helps the review -->
Add a new button on the landing page to update existing CFF.
The button leads to a new page with an input to paste CFF files.
Upon clicking a button, the file is parsed and the CFF object is updated.
Another button is enabled if the parsing is successful that goes to '/start'.
Rules for parsing are in the README.dev.md

- This does not solve the whole importing thing, but it provides the building blocks.

## Instructions to review the pull request

<!--

```shell
cd $(mktemp -d --tmpdir cffinit-pr.XXXXXX)
git clone https://github.com/citation-file-format/cff-initializer-javascript .
git checkout <this branch>
npm clean-install
npm run dev
# go to localhost:8080, see if the app works correctly
npm run lint
npm run test:unit:ci
```

-->
