### PR TITLE
Add preview of the releases to netlify

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -7,6 +7,7 @@ on:
   pull_request:
     branches:
       - main
+  release:
   workflow_dispatch:
 
 jobs:

--- a/README.dev.md
+++ b/README.dev.md
@@ -183,6 +183,7 @@ This section describes how to make a release in 2 parts:
 1. Make a [release on GitHub](https://github.com/citation-file-format/cff-initializer-javascript/releases/new).
 1. Check that the [Publish](https://github.com/citation-file-format/cff-initializer-javascript/actions/workflows/publish.yml) workflow was triggered by making the release, and that it was successful.
 1. Inspect the deployed github.io website [https://citation-file-format.github.io/cff-initializer-javascript/](https://citation-file-format.github.io/cff-initializer-javascript/).
+1. Verify that the [Preview](https://github.com/citation-file-format/cff-initializer-javascript/actions/workflows/preview.yml) workflow was triggered on release deploying a preview of the tag to <https://cffinit.netlify.com/TAG>.
 1. Check whether the [zenodraft](https://github.com/citation-file-format/cff-initializer-javascript/actions/workflows/zenodraft.yml) workflow was triggered correctly when the GitHub release was created.
 1. Go to Zenodo and verify that the new DOI was created by zenodraft.
 


### PR DESCRIPTION
# Pull request details

As a contributor I confirm
- [ ] I read and followed the instructions in [CONTRIBUTING.md](CONTRIBUTING.md)
- [ ] The developer documentation is up to date with the changes introduced in this Pull Request
- [ ] Tests are passing
- [ ] All the workflows are passing

## List of related issues or pull requests

Refs: 
- #717


## Describe the changes made in this pull request

<!-- include screenshots if that helps the review -->
Like the main and the PRs, the release is built and deployed to the preview site https://cffinit.netlify.app.
The release tag is the suffix on the site. See, for instance, https://cffinit.netlify.app/2.0.3.
Since `$GITHUB_REF_NAME` points to that tag when the `github.event_name` is `release`, then the changes are minimal.

## Instructions to review the pull request

<!--

```shell
cd $(mktemp -d --tmpdir cffinit-pr.XXXXXX)
git clone https://github.com/citation-file-format/cff-initializer-javascript .
git checkout <this branch>
npm clean-install
npm run dev
# go to localhost:8080, see if the app works correctly
npm run lint
npm run test:unit:ci
```

-->
