### PR TITLE
Better error evaluation and feedback for Extra CFF Fields

### DIFF
--- a/src/components/Stepper.vue
+++ b/src/components/Stepper.vue
@@ -19,7 +19,7 @@
                 v-bind:caption="stepIndex < 2 ? 'required' : (step !== 'finish' ? 'optional' : '')"
                 v-bind:data-cy="`step-${step}`"
                 v-bind:done="screenVisited(step) && !errorPerStep[step].value"
-                v-bind:error="currentStepIndex != stepIndex && screenVisited(step) && errorPerStep[step].value"
+                v-bind:error="isScreenError(step)"
                 v-bind:header-nav="stepIndex !== currentStepIndex && screenVisited(step) && !anyErrorBetween('start', step)"
                 v-bind:key="step"
                 v-bind:name="step"
@@ -87,6 +87,23 @@ export default {
                 }
             },
             errorPerStep,
+            isScreenError: (step: StepNameType) => {
+                if (!screenVisited(step) || !errorPerStep[step].value || currentStepIndex.value === stepNames.indexOf(step)) {
+                    return false
+                } else if (step === 'extra-cff-fields') {
+                    // If no other screen has error, then it must be the stepNames
+                    const otherScreensHaveErrors = stepNames.reduce((acc, step) => {
+                        if (step === 'extra-cff-fields') {
+                            return acc
+                        } else {
+                            return acc || errorPerStep[step].value
+                        }
+                    }, false)
+                    return !otherScreensHaveErrors
+                } else {
+                    return true
+                }
+            },
             screenVisited,
             setStepName,
             stepName,

--- a/src/store/stepper-errors.ts
+++ b/src/store/stepper-errors.ts
@@ -9,10 +9,11 @@ import {
     screenVersionSpecificQueries
 } from 'src/error-filtering'
 import { computed } from 'vue'
-// import { StepNameType } from 'src/store/app'
+import { useCff } from 'src/store/cff'
 import { useValidation } from 'src/store/validation'
 
 const { errors } = useValidation()
+const { extraCffFields } = useCff()
 
 const errorStateScreenAuthors = computed(() => {
     return screenAuthorQueries
@@ -54,6 +55,6 @@ export const errorPerStep = {
     keywords: errorStateScreenKeywords,
     license: computed(() => false),
     'version-specific': errorStateScreenVersionSpecific,
-    'extra-cff-fields': computed(() => errors.value.length > 0),
+    'extra-cff-fields': computed(() => { return extraCffFields.value.length > 0 && errors.value.length > 0 }),
     finish: computed(() => false)
 }


### PR DESCRIPTION
# Pull request details

As a contributor I confirm
- [ ] I read and followed the instructions in [CONTRIBUTING.md](CONTRIBUTING.md)
- [ ] The developer documentation is up to date with the changes introduced in this Pull Request
- [ ] Tests are passing
- [ ] All the workflows are passing

## List of related issues or pull requests

Refs: 
- #833 


## Describe the changes made in this pull request

<!-- include screenshots if that helps the review -->
The current Extra CFF Fields error verification is limited due to being open-ended.
This adds a check for whether there is something written in that input.
If nothing is written in the Extra CFF Fields, it does not have errors.

Additionally, the stepper feedback is now neutral until it can be sure whether Extra CFF Fields is the place with errors.
Consider a situation where there is a `preferred-citation` in the ECFFF input.
- If `errors.length > 0`, then ECFFF has an error **for sure** only if there are no other errors.

## Instructions to review the pull request

<!--

```shell
cd $(mktemp -d --tmpdir cffinit-pr.XXXXXX)
git clone https://github.com/citation-file-format/cff-initializer-javascript .
git checkout <this branch>
npm clean-install
npm run dev
# go to localhost:8080, see if the app works correctly
npm run lint
npm run test:unit:ci
```

-->
