### PR TITLE
Allow triggering zenodraft manually for when the action is not triggered

### DIFF
--- a/.github/workflows/zenodraft.yml
+++ b/.github/workflows/zenodraft.yml
@@ -4,6 +4,7 @@ on:
   release:
     types:
       - published
+  workflow_dispatch:
 
 jobs:
   publish:

--- a/README.dev.md
+++ b/README.dev.md
@@ -184,7 +184,7 @@ This section describes how to make a release in 2 parts:
 1. Check that the [Publish](https://github.com/citation-file-format/cff-initializer-javascript/actions/workflows/publish.yml) workflow was triggered by making the release, and that it was successful.
 1. Inspect the deployed github.io website [https://citation-file-format.github.io/cff-initializer-javascript/](https://citation-file-format.github.io/cff-initializer-javascript/).
 1. Verify that the [Preview](https://github.com/citation-file-format/cff-initializer-javascript/actions/workflows/preview.yml) workflow was triggered on release deploying a preview of the tag to <https://cffinit.netlify.com/TAG>.
-1. Check whether the [zenodraft](https://github.com/citation-file-format/cff-initializer-javascript/actions/workflows/zenodraft.yml) workflow was triggered correctly when the GitHub release was created.
+1. Check whether the [zenodraft](https://github.com/citation-file-format/cff-initializer-javascript/actions/workflows/zenodraft.yml) workflow was triggered correctly when the GitHub release was created. If it was not, then trigger it manually.
 1. Go to Zenodo and verify that the new DOI was created by zenodraft.
 
 ## References


### PR DESCRIPTION
# Pull request details

As a contributor I confirm
- [ ] I read and followed the instructions in [CONTRIBUTING.md](CONTRIBUTING.md)
- [ ] The developer documentation is up to date with the changes introduced in this Pull Request
- [ ] Tests are passing
- [ ] All the workflows are passing

## List of related issues or pull requests

Refs: 
- #ISSUE_NUMBER


## Describe the changes made in this pull request

<!-- include screenshots if that helps the review -->


## Instructions to review the pull request

<!--

```shell
cd $(mktemp -d --tmpdir cffinit-pr.XXXXXX)
git clone https://github.com/citation-file-format/cff-initializer-javascript .
git checkout <this branch>
npm clean-install
npm run dev
# go to localhost:8080, see if the app works correctly
npm run lint
npm run test:unit:ci
```

-->
